### PR TITLE
Remove unnecessary type overloads for reactive()

### DIFF
--- a/.changeset/tasty-shoes-sit.md
+++ b/.changeset/tasty-shoes-sit.md
@@ -1,0 +1,8 @@
+---
+'signalium': patch
+---
+
+Remove unnecessary type overloads for reactive().
+
+These type overloads were preventing tasks return from Reactives from being
+properly typed.

--- a/packages/signalium/src/internals/core-api.ts
+++ b/packages/signalium/src/internals/core-api.ts
@@ -50,14 +50,6 @@ export function getReactiveFnAndDefinition<T, Args extends unknown[]>(
 }
 
 export function reactive<T, Args extends unknown[]>(
-  fn: (...args: Args) => Promise<T>,
-  opts?: ReactiveOptions<T, Args>,
-): (...args: Args) => DiscriminatedReactivePromise<T>;
-export function reactive<T, Args extends unknown[]>(
-  fn: (...args: Args) => T,
-  opts?: ReactiveOptions<T, Args>,
-): (...args: Args) => T;
-export function reactive<T, Args extends unknown[]>(
   fn: (...args: Args) => T,
   opts?: ReactiveOptions<T, Args>,
 ): ReactiveFn<T, Args> {


### PR DESCRIPTION
These type overloads were preventing tasks return from Reactives from being properly typed.
