### PR TITLE
Bug: computed errors are not cached

### DIFF
--- a/packages/signalium/src/__tests__/bug-errors-not-cached.test.ts
+++ b/packages/signalium/src/__tests__/bug-errors-not-cached.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import { signal, watcher } from 'signalium';
+import { reactive } from './utils/instrumented-hooks.js';
+
+describe('Bug: computed errors are not cached', () => {
+  test('thrown error should be cached and rethrown without recomputing', () => {
+    const s = signal('first');
+
+    let computeCount = 0;
+    const c = reactive(
+      () => {
+        computeCount++;
+        throw new Error(s.value);
+      },
+      { desc: 'throwingComputed' },
+    );
+
+    const w = watcher(() => {
+      try {
+        c();
+      } catch {
+        // swallow
+      }
+    });
+    w.addListener(() => {});
+
+    // First read: computes and throws
+    expect(() => c()).toThrow('first');
+    expect(computeCount).toBe(1);
+
+    // Second read with no dependency change: should rethrow cached error
+    // without recomputing. In Preact Signals, Vue, and TC39 polyfill,
+    // computeCount stays at 1. In signalium, it increments to 2.
+    expect(() => c()).toThrow('first');
+    expect(computeCount).toBe(1); // FAILS: actual is 2
+
+    // After a dependency change, recompute is expected
+    s.value = 'second';
+    expect(() => c()).toThrow('second');
+    expect(computeCount).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- When a reactive function throws, every subsequent read recomputes the function from scratch instead of caching and rethrowing the error.
- Root cause: `runSignal()` throws before `checkSignal()` reaches `signal._state = Clean` (get.ts:129), leaving the signal permanently `Dirty`.
- Every other signals framework in the ecosystem (Preact Signals, Vue, SolidJS, TC39 polyfill) caches thrown errors.

## Reproduction

```typescript
const s = signal('first');
let computeCount = 0;
const c = reactive(() => { computeCount++; throw new Error(s.value); });

expect(() => c()).toThrow('first');
expect(computeCount).toBe(1);

// Second read — no deps changed, should rethrow cached error
expect(() => c()).toThrow('first');
expect(computeCount).toBe(1); // FAILS: actual is 2
```

## Test plan

- [ ] `npx vitest run --project unit src/__tests__/bug-errors-not-cached.test.ts` (currently fails, demonstrating the bug)

Made with [Cursor](https://cursor.com)