### PR TITLE
Add repro for entity stream flag desync

### DIFF
--- a/packages/query/src/__tests__/entity-stream.test.ts
+++ b/packages/query/src/__tests__/entity-stream.test.ts
@@ -278,6 +278,92 @@ describe('Entity Streaming', () => {
   });
 
   describe('Partial Updates', () => {
+    it('can desync outer mutable reduce flags from reducer output after entity stream updates', async () => {
+      let streamCallback: ((update: any) => void) | undefined;
+
+      const Price = entity(
+        () => ({
+          __typename: t.typename('Price'),
+          id: t.id,
+          price: t.optional(t.number),
+        }),
+        undefined,
+        {
+          stream: {
+            subscribe: (_context, _id, onUpdate) => {
+              streamCallback = onUpdate;
+              return () => {};
+            },
+          },
+        },
+      );
+
+      const getPrices = query(() => ({
+        path: '/prices',
+        response: {
+          prices: t.record(Price),
+        },
+      }));
+
+      mockFetch.get('/prices', {
+        prices: {
+          a: {
+            __typename: 'Price',
+            id: 'a',
+          },
+        },
+      });
+
+      await testWithClient(client, async () => {
+        const tokens = signal([{ id: 'a', embeddedPrice: undefined as number | undefined }]);
+
+        const getLocalPortfolioValue = reactive(async () => {
+          const { prices } = await getPrices();
+
+          let hasPriceData = false;
+
+          const totals = tokens.value.reduce(
+            (acc, token) => {
+              const tokenPrice = prices[token.id]?.price ?? token.embeddedPrice;
+
+              if (tokenPrice != null) {
+                hasPriceData = true;
+              }
+
+              return {
+                resolvedPriceCount: acc.resolvedPriceCount + (tokenPrice != null ? 1 : 0),
+              };
+            },
+            { resolvedPriceCount: 0 },
+          );
+
+          return {
+            hasPriceData,
+            resolvedPriceCount: totals.resolvedPriceCount,
+          };
+        });
+
+        const initial = await getLocalPortfolioValue();
+        expect(initial).toEqual({
+          hasPriceData: false,
+          resolvedPriceCount: 0,
+        });
+
+        expect(streamCallback).toBeDefined();
+
+        await new Promise<void>(resolve => {
+          setTimeout(() => {
+            streamCallback?.({ price: 1 });
+            resolve();
+          }, 0);
+        });
+
+        const warm = await getLocalPortfolioValue();
+        expect(warm.resolvedPriceCount).toBe(1);
+        expect(warm.hasPriceData).toBe(true);
+      });
+    });
+
     it('should merge stream updates correctly with existing entity data', async () => {
       let streamCallback: ((update: any) => void) | undefined;
 

--- a/packages/query/src/__tests__/entity-stream.test.ts
+++ b/packages/query/src/__tests__/entity-stream.test.ts
@@ -364,6 +364,87 @@ describe('Entity Streaming', () => {
       });
     });
 
+    it('stays aligned when reducer state derives hasPriceData without outer mutation', async () => {
+      let streamCallback: ((update: any) => void) | undefined;
+
+      const Price = entity(
+        () => ({
+          __typename: t.typename('Price'),
+          id: t.id,
+          price: t.optional(t.number),
+        }),
+        undefined,
+        {
+          stream: {
+            subscribe: (_context, _id, onUpdate) => {
+              streamCallback = onUpdate;
+              return () => {};
+            },
+          },
+        },
+      );
+
+      const getPrices = query(() => ({
+        path: '/prices',
+        response: {
+          prices: t.record(Price),
+        },
+      }));
+
+      mockFetch.get('/prices', {
+        prices: {
+          a: {
+            __typename: 'Price',
+            id: 'a',
+          },
+        },
+      });
+
+      await testWithClient(client, async () => {
+        const tokens = signal([{ id: 'a', embeddedPrice: undefined as number | undefined }]);
+
+        const getLocalPortfolioValue = reactive(async () => {
+          const { prices } = await getPrices();
+
+          return tokens.value.reduce(
+            (acc, token) => {
+              const tokenPrice = prices[token.id]?.price ?? token.embeddedPrice;
+
+              return {
+                hasPriceData: acc.hasPriceData || tokenPrice != null,
+                resolvedPriceCount: acc.resolvedPriceCount + (tokenPrice != null ? 1 : 0),
+              };
+            },
+            {
+              hasPriceData: false,
+              resolvedPriceCount: 0,
+            },
+          );
+        });
+
+        const initial = await getLocalPortfolioValue();
+        expect(initial).toEqual({
+          hasPriceData: false,
+          resolvedPriceCount: 0,
+        });
+
+        expect(streamCallback).toBeDefined();
+
+        await new Promise<void>(resolve => {
+          setTimeout(() => {
+            streamCallback?.({ price: 1 });
+            resolve();
+          }, 0);
+        });
+
+        const warm = await getLocalPortfolioValue();
+        expect(warm).toEqual({
+          hasPriceData: true,
+          resolvedPriceCount: 1,
+        });
+      });
+    });
+
     it('should merge stream updates correctly with existing entity data', async () => {
       let streamCallback: ((update: any) => void) | undefined;
 


### PR DESCRIPTION
## Summary
- add a focused failing regression test in `packages/query/src/__tests__/entity-stream.test.ts`
- reproduce a case where `resolvedPriceCount` updates after an entity stream update but an outer mutable flag (`hasPriceData`) stays stale
- keep the repro minimal by deferring the stream callback one tick without extra helper sleeps

## Repro details
The new test starts with a query result where `prices.a.price` is undefined, then sends a stream update setting `price: 1`. After the update, the reactive returns:
- `resolvedPriceCount === 1`
- `hasPriceData === false`

That mismatch mirrors the wallet bug where local portfolio value was treated as missing even though the reducer had already observed valid prices.

## Test plan
- [x] Run `npx vitest run --project unit src/__tests__/entity-stream.test.ts -t \"can desync outer mutable reduce flags from reducer output after entity stream updates\"`
- [x] Confirm the test fails with `expected false to be true`


Made with [Cursor](https://cursor.com)