### PR TITLE
feat(query): support dynamic refetchInterval via callback function

### DIFF
--- a/packages/query/src/QueryClient.ts
+++ b/packages/query/src/QueryClient.ts
@@ -62,11 +62,17 @@ export function resolveBaseUrl(baseUrl: BaseUrlValue | undefined): string | unde
   return baseUrl.value; // Signal
 }
 
+/**
+ * Callback that receives query state and returns an interval or `false` to skip.
+ * Useful for stopping or slowing polling based on error state (e.g. 404s).
+ */
+export type RefetchIntervalFn = (query: { isRejected: boolean; error: unknown }) => RefetchInterval | false;
+
 export interface QueryCacheOptions {
   maxCount?: number;
   gcTime?: number; // milliseconds - only applies to on-disk/persistent storage cleanup
   staleTime?: number;
-  refetchInterval?: RefetchInterval;
+  refetchInterval?: RefetchInterval | RefetchIntervalFn;
   networkMode?: NetworkMode; // default: NetworkMode.Online
   retry?: RetryConfig | number | false; // default: 3 on client, 0 on server
   refreshStaleOnReconnect?: boolean; // default: true

--- a/packages/query/src/RefetchManager.ts
+++ b/packages/query/src/RefetchManager.ts
@@ -1,4 +1,4 @@
-import { QueryType } from './QueryClient.js';
+import { QueryType, type QueryCacheOptions } from './QueryClient.js';
 import type { QueryResultImpl } from './QueryResult.js';
 
 const BASE_TICK_INTERVAL = 1000; // 1 second
@@ -8,8 +8,11 @@ export class RefetchManager {
   private intervalId: NodeJS.Timeout;
   private clock: number = 0; // Increments by 1000ms on each tick
 
-  // Buckets: Map of actual interval -> Set of query instances
+  // Buckets: Map of actual interval -> Set of query instances (static intervals only)
   private buckets = new Map<number, Set<QueryResultImpl<any>>>();
+
+  // Queries with dynamic (function) refetchInterval, evaluated every tick
+  private dynamicQueries = new Set<QueryResultImpl<any>>();
 
   constructor(private multiplier: number = 1) {
     // Start the timer immediately and keep it running
@@ -22,13 +25,18 @@ export class RefetchManager {
       return; // Streams don't have refetch intervals
     }
 
-    const interval = instance.def.cache?.refetchInterval;
+    const refetchInterval = instance.def.cache?.refetchInterval;
 
-    if (!interval) {
+    if (!refetchInterval) {
       return;
     }
 
-    const actualInterval = interval * this.multiplier;
+    if (typeof refetchInterval === 'function') {
+      this.dynamicQueries.add(instance);
+      return;
+    }
+
+    const actualInterval = refetchInterval * this.multiplier;
     // Add to bucket by actual interval
     let bucket = this.buckets.get(actualInterval);
     if (!bucket) {
@@ -43,13 +51,18 @@ export class RefetchManager {
       return; // Streams don't have refetch intervals
     }
 
-    const interval = query.def.cache?.refetchInterval;
+    const refetchInterval = query.def.cache?.refetchInterval;
 
-    if (!interval) {
+    if (!refetchInterval) {
       return;
     }
 
-    const actualInterval = interval * this.multiplier;
+    if (typeof refetchInterval === 'function') {
+      this.dynamicQueries.delete(query);
+      return;
+    }
+
+    const actualInterval = refetchInterval * this.multiplier;
     // Remove from bucket
     const bucket = this.buckets.get(actualInterval);
     if (bucket) {
@@ -64,7 +77,7 @@ export class RefetchManager {
   private tick() {
     this.clock += BASE_TICK_INTERVAL * this.multiplier;
 
-    // Only process buckets where clock is aligned with the interval
+    // Process static-interval buckets where clock is aligned with the interval
     for (const [interval, bucket] of this.buckets.entries()) {
       if (this.clock % interval === 0) {
         // Process all queries in this bucket
@@ -74,6 +87,23 @@ export class RefetchManager {
             query.refetch();
           }
         }
+      }
+    }
+
+    // Process dynamic-interval queries
+    for (const query of this.dynamicQueries) {
+      if (query.isFetching) continue;
+
+      const fn = (query.def.cache as QueryCacheOptions | undefined)?.refetchInterval;
+      if (typeof fn !== 'function') continue;
+
+      const interval = fn({ isRejected: query.isRejected, error: query.error });
+
+      if (interval === false || !interval) continue;
+
+      const actualInterval = interval * this.multiplier;
+      if (this.clock % actualInterval === 0) {
+        query.refetch();
       }
     }
 

--- a/packages/query/src/__tests__/refetch-interval.test.ts
+++ b/packages/query/src/__tests__/refetch-interval.test.ts
@@ -259,4 +259,143 @@ describe('RefetchInterval', () => {
       });
     });
   });
+
+  describe('Dynamic Refetch Interval (function)', () => {
+    it('should stop refetching when function returns false on error', async () => {
+      let callCount = 0;
+      mockFetch.get('/maybe-404', () => {
+        callCount++;
+        throw new Error('Not found');
+      });
+
+      const getMaybe404 = query(() => ({
+        path: '/maybe-404',
+        response: { n: t.number },
+        cache: {
+          refetchInterval: (q: { isRejected: boolean }) => (q.isRejected ? false : RefetchInterval.Every1Second),
+          retry: false,
+        },
+      }));
+
+      await testWithClient(client, async () => {
+        const relay = getMaybe404();
+        try {
+          await relay;
+        } catch {
+          // Expected: initial fetch errors
+        }
+
+        const countAfterInitial = callCount;
+
+        // Wait several intervals — should NOT refetch since function returns false
+        await sleep(350);
+
+        expect(callCount).toBe(countAfterInitial);
+      });
+    });
+
+    it('should keep refetching when function returns an interval on success', async () => {
+      let callCount = 0;
+      mockFetch.get('/ok', () => ({ n: ++callCount }));
+
+      const getOk = query(() => ({
+        path: '/ok',
+        response: { n: t.number },
+        cache: {
+          refetchInterval: (q: { isRejected: boolean }) =>
+            q.isRejected ? false : RefetchInterval.Every1Second,
+        },
+      }));
+
+      await testWithClient(client, async () => {
+        const relay = getOk();
+        await relay;
+        expect(relay.value).toEqual({ n: 1 });
+
+        // Wait for refetches
+        await sleep(350);
+
+        // Should have refetched multiple times since there's no error
+        expect(callCount).toBeGreaterThanOrEqual(3);
+      });
+    });
+
+    it('should resume refetching when error clears', async () => {
+      let callCount = 0;
+      let shouldError = true;
+      mockFetch.get('/flaky', () => {
+        callCount++;
+        if (shouldError) throw new Error('Temporary error');
+        return { n: callCount };
+      });
+
+      const getFlaky = query(() => ({
+        path: '/flaky',
+        response: { n: t.number },
+        cache: {
+          refetchInterval: (q: { isRejected: boolean }) =>
+            q.isRejected ? RefetchInterval.Every5Seconds : RefetchInterval.Every1Second,
+          retry: false,
+        },
+      }));
+
+      await testWithClient(client, async () => {
+        const relay = getFlaky();
+        try {
+          await relay;
+        } catch {
+          // Expected
+        }
+
+        // In error state — dynamic interval is 5s (500ms at 0.1x).
+        // At 1s interval (100ms at 0.1x), it should NOT refetch.
+        const countAfterError = callCount;
+        await sleep(250);
+        // Should not have refetched at 1s cadence since error interval is 5s
+        expect(callCount).toBeLessThanOrEqual(countAfterError + 1);
+
+        // Now fix the endpoint and wait for the 5s interval to hit
+        shouldError = false;
+        await sleep(400);
+
+        // Should have refetched at least once after recovering
+        expect(callCount).toBeGreaterThan(countAfterError);
+      });
+    });
+
+    it('should work alongside static interval queries', async () => {
+      let staticCount = 0;
+      let dynamicCount = 0;
+      mockFetch.get('/static', () => ({ n: ++staticCount }));
+      mockFetch.get('/dynamic', () => ({ n: ++dynamicCount }));
+
+      const getStatic = query(() => ({
+        path: '/static',
+        response: { n: t.number },
+        cache: { refetchInterval: RefetchInterval.Every1Second },
+      }));
+
+      const getDynamic = query(() => ({
+        path: '/dynamic',
+        response: { n: t.number },
+        cache: {
+          refetchInterval: (_q: { isRejected: boolean }) => RefetchInterval.Every1Second,
+        },
+      }));
+
+      await testWithClient(client, async () => {
+        const relayStatic = getStatic();
+        const relayDynamic = getDynamic();
+
+        await relayStatic;
+        await relayDynamic;
+
+        await sleep(350);
+
+        // Both should refetch at roughly the same rate
+        expect(staticCount).toBeGreaterThanOrEqual(3);
+        expect(dynamicCount).toBeGreaterThanOrEqual(3);
+      });
+    });
+  });
 });

--- a/packages/query/src/index.ts
+++ b/packages/query/src/index.ts
@@ -1,7 +1,7 @@
 export * from './types.js';
 
 export { QueryClient, QueryClientContext, addOptimisticInsert, removeOptimisticInsert } from './QueryClient.js';
-export type { QueryContext } from './QueryClient.js';
+export type { QueryContext, RefetchIntervalFn } from './QueryClient.js';
 export { t, entity, registerFormat } from './typeDefs.js';
 export { query, infiniteQuery, streamQuery } from './query.js';
 export { mutation } from './mutation.js';


### PR DESCRIPTION
## Summary

- Widen `QueryCacheOptions.refetchInterval` to accept `(query: { isRejected: boolean; error: unknown }) => RefetchInterval | false` in addition to a static `RefetchInterval` enum
- Dynamic-interval queries are tracked in a separate `Set` and evaluated every tick, preserving the existing bucket optimization for static intervals (zero perf regression)
- Export new `RefetchIntervalFn` type for consumer convenience

## Motivation

The Phantom wallet switched single-token price fetches from `POST /price/v1` (always returns 200) to individual `GET /price/v1/[chainId]/address/[address]` (returns 404 when price not found). The old React Query code stopped polling on 404 via a conditional `refetchInterval` callback, but `@signalium/query`'s `refetchInterval` was a static number — no way to stop or change the interval based on error state.

This caused a **27x increase in 404s**: every token without a price was re-requested every 5 seconds, forever.

### Usage

```typescript
const getPriceQuery = query(() => ({
  path: "/price/v1/[chainId]/address/[address]",
  response: PriceEntity,
  cache: {
    refetchInterval: (q) => q.isRejected ? false : RefetchInterval.Every5Seconds,
  },
}));
```

## Test plan

- [x] Existing refetch-interval tests pass (no regression)
- [x] New test: stops refetching when function returns `false` on error
- [x] New test: keeps refetching when function returns an interval on success
- [x] New test: resumes refetching when error clears (backoff then recovery)
- [x] New test: dynamic and static interval queries coexist correctly
- [x] TypeScript type check passes

**Note:** This PR targets `main` but is based on `@signalium/query@1.1.2` (the version Phantom wallet consumes). It will need to be rebased or cherry-picked onto the current `main` which has the fetchium rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)