### PR TITLE
feat(signalium): native WeakRef GC, refactor signal suspension/pausing

### DIFF
--- a/.changeset/weakref-gc-and-simplified-suspension.md
+++ b/.changeset/weakref-gc-and-simplified-suspension.md
@@ -1,0 +1,36 @@
+---
+'signalium': major
+---
+
+Switch to native `WeakRef` for scope-cached signals, remove suspension from the core graph, and introduce `PauseSignalsProvider`.
+
+### Native WeakRef GC
+
+`SignalScope` now stores signals as `WeakRef` entries instead of strong references with manual GC sweeps. Signals stay alive as long as something holds a strong reference (the `deps` chain, a React component closure, a local variable, etc.). When nothing references a signal, the JS garbage collector reclaims it naturally.
+
+Removed:
+- The `WeakRef` polyfill (`weakref.ts`) — environments without native `WeakRef` are no longer supported.
+- The manual GC sweep system (`markForGc`, `removeFromGc`, `sweepGc`, `gcCandidates`, `scheduleGcSweep`, `scheduleIdleCallback`).
+- `reset()` on `ReactiveSignal` — signals are no longer eagerly torn down on unwatch. Their value and dep graph are preserved for reuse if re-watched before GC collects them.
+
+### Suspension removed from core
+
+The core signal graph has zero suspension concepts. Removed:
+- `suspendCount` field and `_isSuspended` getter on `ReactiveSignal`
+- `setSuspended()` method and `isSuspendedListener` flag
+- `watchSuspendedSignal`, `unwatchSuspendedSignal`, `suspendSignal`, `resumeSignal`
+- The `parentIsSuspended` parameter on `watchSignal` / `unwatchSignal`
+- The `isSuspending` branch in `deactivateSignal`
+
+### `PauseSignalsProvider` (replaces `SuspendSignalsProvider`)
+
+`SuspendSignalsProvider` is replaced by `PauseSignalsProvider` to avoid confusion with React Suspense.
+
+`PauseSignalsProvider` uses a stable `PauseSignalsManager` context (not a changing boolean), so toggling the `value` prop does not re-render descendants. React hooks register their signals during render; the manager calls `watchSignal` / `unwatchSignal` directly to pause and resume the signal graph. Signals mounted inside an already-paused provider skip activation entirely.
+
+### Breaking changes
+
+- `SuspendSignalsProvider` → `PauseSignalsProvider`
+- `useSignalsSuspended()` is removed from the public API.
+- `setSuspended()` is removed from the `Watcher` interface.
+- Environments without native `WeakRef` are no longer supported.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ When a signal has external listeners (React components, watchers):
 | `context.ts`                 | `ScopeContext`, `useScope()`, `useContext()`                        |
 | `provider.tsx`               | `ContextProvider` component                                         |
 | `use-signal.ts`              | `useSignal()` — creates a StateSignal scoped to a component         |
-| `suspend-signals-context.ts` | Suspended signals context for loading states                        |
+| `pause-signals-context.ts`   | `PauseSignalsProvider` for pausing signal subscriptions             |
 
 `useReactive` has three code paths (function, StateSignal, direct ReactivePromise), each calling the same hook pattern: one `useSyncExternalStore` for primary subscription + one for deep dependency tracking via `CONSUME_DEEP`.
 

--- a/docs/src/app/api/signalium/react/page.md
+++ b/docs/src/app/api/signalium/react/page.md
@@ -316,21 +316,21 @@ const App = component(() => (
 | inherit  | `boolean`                     | Inherit parent scope (default true) |
 | children | `React.ReactNode`             | Children                            |
 
-### SuspendSignalsProvider
+### PauseSignalsProvider
 
 ```tsx
-export function SuspendSignalsProvider(props: {
+export function PauseSignalsProvider(props: {
   value: boolean;
   children: React.ReactNode;
 }): React.ReactElement;
 ```
 
-Temporarily suspend signal subscriptions for an entire React subtree. When `value={true}`, components in the subtree will not subscribe to signal updates, preventing re-renders and allowing signals to be garbage collected if not used elsewhere. When `value={false}`, components resume normal signal subscription.
+Temporarily pause signal subscriptions for an entire React subtree. When `value={true}`, signals in the subtree are unwatched — relays are torn down, updates don't trigger re-renders, and last known values are preserved. When `value={false}`, signals are re-watched and resume normal updates. Toggling `value` does not re-render descendants (the provider uses a stable context reference internally).
 
 This is particularly useful for React Native applications where screens remain mounted but inactive (e.g., background tabs), or when you need to temporarily pause expensive computations for performance reasons.
 
 ```tsx
-import { component, SuspendSignalsProvider, useSignal } from 'signalium/react';
+import { component, PauseSignalsProvider, useSignal } from 'signalium/react';
 import { reactive } from 'signalium';
 
 const expensiveComputation = reactive((input: Signal<number>) => {
@@ -345,18 +345,18 @@ const TabNavigator = component(() => {
   return (
     <>
       {/* Home tab - active when selected */}
-      <SuspendSignalsProvider value={activeTab !== 'home'}>
+      <PauseSignalsProvider value={activeTab !== 'home'}>
         <div style={{ display: activeTab === 'home' ? 'block' : 'none' }}>
           <HomeTab data={data} />
         </div>
-      </SuspendSignalsProvider>
+      </PauseSignalsProvider>
 
-      {/* Profile tab - suspended when not selected */}
-      <SuspendSignalsProvider value={activeTab !== 'profile'}>
+      {/* Profile tab - paused when not selected */}
+      <PauseSignalsProvider value={activeTab !== 'profile'}>
         <div style={{ display: activeTab === 'profile' ? 'block' : 'none' }}>
           <ProfileTab data={data} />
         </div>
-      </SuspendSignalsProvider>
+      </PauseSignalsProvider>
 
       <button onClick={() => setActiveTab('home')}>Home</button>
       <button onClick={() => setActiveTab('profile')}>Profile</button>
@@ -371,25 +371,25 @@ const TabScreen = component(() => {
   const isFocused = useIsFocused();
 
   return (
-    <SuspendSignalsProvider value={!isFocused}>
+    <PauseSignalsProvider value={!isFocused}>
       <YourTabContent />
-    </SuspendSignalsProvider>
+    </PauseSignalsProvider>
   );
 });
 ```
 
 **Behavior:**
 
-- **Suspended (`value={true}`)**: Components don't subscribe to signals, updates don't trigger re-renders, last known values are retained, signals may be garbage collected
+- **Paused (`value={true}`)**: Signals are unwatched, relays are torn down, updates don't trigger re-renders, last known values are preserved
 - **Active (`value={false}`)**: Normal signal subscription, updates trigger re-renders, signals show current values
 
 **Important notes:**
 
-- Suspended signals will still rerun if the component tree re-renders for other reasons (e.g., prop changes), but they will compute with the last known values for any Relays in the suspended subtree
-- For permanent cleanup, unmount the component normally — suspension is for temporary pauses
+- Paused signals will still rerun if the component tree re-renders for other reasons (e.g., prop changes), but they will compute with the last known values for any relays in the paused subtree
+- For permanent cleanup, unmount the component normally — pausing is for temporary resource savings
 - Works with both `useReactive` and `component()` which are the primary signal entry points in React
 
-| Prop     | Type              | Description                      |
-| -------- | ----------------- | -------------------------------- |
-| value    | `boolean`         | Whether to suspend (true) or not |
-| children | `React.ReactNode` | Children to suspend/resume       |
+| Prop     | Type              | Description                       |
+| -------- | ----------------- | --------------------------------- |
+| value    | `boolean`         | Whether to pause (true) or not    |
+| children | `React.ReactNode` | Children to pause/resume          |

--- a/docs/src/app/core/react/page.md
+++ b/docs/src/app/core/react/page.md
@@ -400,47 +400,47 @@ Multiple contexts can be provided to the `ContextProvider` component, removing t
 
 The primary reason for this is for performance. Each time we add a new provider, we create a new scope and rerun all of the Reactive Functions in that scope. This is why it's generally better to flatten multiple Contexts into a single provider, rather than nesting them.
 
-## Suspending Signals
+## Pausing Signals
 
 In certain scenarios, particularly in React Native applications, you may need to temporarily pause signal updates without fully unmounting components. For example, React Native keeps tab screens mounted in the background, but you don't want those background screens consuming resources or receiving updates.
 
-Signalium provides `SuspendSignalsProvider` to handle this use case:
+Signalium provides `PauseSignalsProvider` to handle this use case:
 
 ```tsx
-import { SuspendSignalsProvider } from 'signalium/react';
+import { PauseSignalsProvider } from 'signalium/react';
 
 function TabNavigator() {
   const [activeTab, setActiveTab] = useState('home');
 
   return (
     <>
-      <SuspendSignalsProvider value={activeTab !== 'home'}>
+      <PauseSignalsProvider value={activeTab !== 'home'}>
         <HomeScreen />
-      </SuspendSignalsProvider>
+      </PauseSignalsProvider>
 
-      <SuspendSignalsProvider value={activeTab !== 'profile'}>
+      <PauseSignalsProvider value={activeTab !== 'profile'}>
         <ProfileScreen />
-      </SuspendSignalsProvider>
+      </PauseSignalsProvider>
     </>
   );
 }
 ```
 
-### How Suspension Works
+### How Pausing Works
 
-When a signal subtree is suspended (`SuspendSignalsContext.Provider value={true}`):
+When a signal subtree is paused (`PauseSignalsProvider value={true}`):
 
-1. **No subscriptions**: Components don't subscribe to signal updates
+1. **Unwatched**: Signals are unwatched, relays are torn down
 2. **No re-renders**: Signal updates don't trigger component re-renders
-3. **Value retention**: Signals maintain their last known value in the component
-4. **Automatic GC**: Signals are unwatched and may be garbage collected if not used elsewhere
+3. **Value preservation**: Signals maintain their last known value in the component
+4. **No descendant re-renders**: Toggling the provider does not re-render descendants (the context value is a stable reference)
 
 When the signal subtree is resumed (`value={false}`):
 
-1. **Resubscribe**: Components subscribe to signals again
+1. **Re-watched**: Signals are re-watched, relays re-bootstrap
 2. **Immediate sync**: Components immediately show the current signal values
 3. **Normal operation**: Signal updates resume triggering re-renders
 
 {% callout type="warning" title="Note" %}
-Suspended signals will still rerun if accessed manually. This means that if the component tree rerenders for any other reason, the signals will rerun as well. However, none of the Relays _within_ the suspended subtree will be reactivated, so it will recompute with the last known values for all Relays.
+Paused signals will still rerun if accessed manually. This means that if the component tree rerenders for any other reason, the signals will rerun as well. However, none of the relays _within_ the paused subtree will be reactivated, so it will recompute with the last known values for all relays.
 {% /callout %}

--- a/packages/signalium/src/__tests__/gc.test.ts
+++ b/packages/signalium/src/__tests__/gc.test.ts
@@ -1,19 +1,29 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { reactive, context, withContexts, watcher, signal } from '../index.js';
-import { SignalScope, getGlobalScope, clearGlobalContexts } from '../internals/contexts.js';
+import { getGlobalScope, clearGlobalContexts, getSignalsMap, SignalScope } from '../internals/contexts.js';
+import { watchSignal, unwatchSignal } from '../internals/watch.js';
+import { schedulePull } from '../internals/scheduling.js';
+import { ReactiveSignal } from '../internals/reactive.js';
 import { nextTick, sleep } from './utils/async.js';
 
-// Helper to access private properties for testing
-const getSignalsMap = (scope: SignalScope) => {
-  return (scope as any).signals as Map<number, any>;
-};
-
-const getGCCandidates = (scope: SignalScope) => {
-  return (scope as any).gcCandidates as Set<any>;
+const getLiveSignalCount = (scope: SignalScope = getGlobalScope()) => {
+  const signals = getSignalsMap(scope);
+  let count = 0;
+  for (const ref of signals.values()) {
+    if (ref.deref() !== undefined) count++;
+  }
+  return count;
 };
 
 const getContextChildScope = (scope: SignalScope): SignalScope => {
   return (scope as any).children.values().next().value as SignalScope;
+};
+
+const suspend = (w: unknown) => unwatchSignal(w as ReactiveSignal<any, any>);
+const resume = (w: unknown) => {
+  const signal = w as ReactiveSignal<any, any>;
+  watchSignal(signal);
+  schedulePull(signal);
 };
 
 describe('Garbage Collection', () => {
@@ -21,187 +31,168 @@ describe('Garbage Collection', () => {
     clearGlobalContexts();
   });
 
-  it('should automatically garbage collect unwatched signals', async () => {
+  it('unwatched signals are deactivated and marked dirty for revalidation', async () => {
     const testSignal = reactive(() => 42);
 
     const w = watcher(() => testSignal());
 
-    // Watch the signal
     const unwatch = w.addListener(() => {
       testSignal();
     });
 
     await nextTick();
 
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    expect(getLiveSignalCount()).toBe(1);
 
-    // Unwatch the signal
     unwatch();
+    await nextTick();
 
-    await sleep(50);
+    // Signal is still in the scope (WeakRef not collected yet) but deactivated.
+    const unwatch2 = w.addListener(() => {});
+    await nextTick();
 
-    // Signal should be garbage collected
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
+    expect(getLiveSignalCount()).toBe(1);
+    unwatch2();
   });
 
-  it('should not garbage collect signals that are still being watched', async () => {
-    // Create a signal
-    const watchedSignal = reactive(() => 'watched');
+  it('should not deactivate signals that are still being watched', async () => {
+    let evalCount = 0;
+    const watchedSignal = reactive(() => {
+      evalCount++;
+      return 'watched';
+    });
 
     const w = watcher(() => watchedSignal());
 
-    // Watch the signal but don't unwatch
     w.addListener(() => {
       watchedSignal();
     });
 
     await nextTick();
 
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    expect(getLiveSignalCount()).toBe(1);
+    expect(evalCount).toBe(1);
 
     await sleep(50);
 
-    // Signal should still be in the scope because it's being watched
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    expect(getLiveSignalCount()).toBe(1);
+    expect(evalCount).toBe(1);
   });
 
   it('should handle context-scoped signals correctly', async () => {
-    // Create a context
     const TestContext = context('test');
 
-    // Create signals in context
     let contextSignal: any;
+    let evalCount = 0;
 
-    withContexts([[TestContext, 'value']], () => {
-      contextSignal = reactive(() => 'context-scoped');
-
-      const w = watcher(() => contextSignal());
-
-      // Watch and unwatch
-      const unwatch = w.addListener(() => {
-        contextSignal();
+    const w = withContexts([[TestContext, 'value']], () => {
+      contextSignal = reactive(() => {
+        evalCount++;
+        return 'context-scoped';
       });
 
-      unwatch();
+      return watcher(() => contextSignal());
     });
 
+    const unwatch = w.addListener(() => {});
     await nextTick();
 
-    // Get the context scope (this is a bit hacky for testing)
+    expect(evalCount).toBe(1);
+
     const contextScope = getContextChildScope(getGlobalScope());
+    expect(getLiveSignalCount(contextScope)).toBe(1);
 
-    await sleep(50);
+    unwatch();
+    await nextTick();
 
-    // Signal should be garbage collected from the context scope
-    expect(getSignalsMap(contextScope).size).toBe(0);
+    // Signal is deactivated but still alive (local var holds reference).
+    // Re-watching returns the cached value since deps haven't changed.
+    const unwatch2 = w.addListener(() => {});
+    await nextTick();
+
+    expect(evalCount).toBe(1);
+    unwatch2();
   });
 
-  it('should remove signal from GC candidates if watched again', async () => {
-    // Create a signal
-    const signal = reactive(() => 'rewatch');
+  it('re-watching a signal after unwatch reactivates it', async () => {
+    let evalCount = 0;
+    const s = reactive(() => {
+      evalCount++;
+      return 'rewatch';
+    });
 
-    const w = watcher(() => signal());
+    const w = watcher(() => s());
 
-    // Watch and unwatch
     const unwatch = w.addListener(() => {});
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     w.value;
 
     await nextTick();
 
-    // Signal should be in the scope
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
+    expect(getLiveSignalCount()).toBe(1);
+    expect(evalCount).toBe(1);
 
     unwatch();
     await nextTick();
 
-    // Signal should be in GC candidates
-    expect(getGCCandidates(getGlobalScope()).size).toBe(2);
-
-    // Watch again
+    // Watch again — deps are preserved, so cached values are reused
     w.addListener(() => {});
     // eslint-disable-next-line @typescript-eslint/no-unused-expressions
     w.value;
 
     await nextTick();
 
-    // Signal should be removed from GC candidates
-    expect(getSignalsMap(getGlobalScope()).size).toBe(1);
-    expect(getGCCandidates(getGlobalScope()).size).toBe(0);
+    expect(getLiveSignalCount()).toBe(1);
+    expect(evalCount).toBe(1);
   });
 
-  it('propagates suspension to dependencies and tears them down without GC', async () => {
-    // Track how many times our reactive function reruns.
+  it('unwatching preserves values and rewatching does not rerun if deps unchanged', async () => {
     let evalCount = 0;
 
     const source = signal(1);
-
-    // Direct consumers of a signal always rerun when it changes. So we
-    // need a _second_ reactive function to observe caching behavior.
     const mid1 = reactive(() => source.value + 1);
-
-    // This second function increments the counter. It will _not_ rerun
-    // if `mid1`'s output hasn't changed.
     const mid2 = reactive(() => {
       evalCount++;
       return mid1() + 1;
     });
 
     const top = watcher(() => mid2());
-
     const unwatchTop = top.addListener(() => {});
 
-    // Wait for initial activation.
     await nextTick();
 
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+    expect(getLiveSignalCount()).toBe(2);
 
-    // Verify the counter works by changing source.
     source.value = 2;
     await nextTick();
 
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend the Watcher — function should not rerun.
-    top.setSuspended(true);
+    // Unwatch the watcher — function should not rerun.
+    suspend(top);
     await nextTick();
 
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+    expect(getLiveSignalCount()).toBe(2);
 
-    // Change source while suspended — still no rerun.
+    // Change source while unwatched — still no rerun.
     source.value = 3;
     await nextTick();
 
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Reset source to 2 and resume. The _output_ of `mid1` is still
-    // 2 + 1 = 3, unchanged. So `mid2` should NOT rerun if cached.
-    //
-    // If `mid2` had been GC'd, it would have to be recreated, and the
-    // counter would increment.
+    // Reset source to 2 and rewatch. Deps reactivated without Dirty marking.
     source.value = 2;
-    top.setSuspended(false);
+    resume(top);
     await nextTick();
 
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Fully unwatch — counter should remain unchanged.
     unwatchTop();
-    await sleep(20);
-
-    expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
   });
 
-  it('shared dependency stays active until all consumers suspend', async () => {
-    // Track how many times mid2 re-evaluates.
+  it('shared dependency stays active until all consumers unwatch', async () => {
     let evalCount = 0;
 
     const source = signal(1);
@@ -211,7 +202,6 @@ describe('Garbage Collection', () => {
       return mid1() + 1;
     });
 
-    // Two watchers share the same dependency chain.
     const topA = watcher(() => mid2());
     const topB = watcher(() => mid2());
 
@@ -220,38 +210,28 @@ describe('Garbage Collection', () => {
 
     await nextTick();
 
-    // Both watchers share mid2 — it evaluates once.
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend only A — mid2 stays active because B is still watching.
-    topA.setSuspended(true);
+    // Unwatch only A — mid2 stays active because B is still watching.
+    suspend(topA);
     source.value = 2;
     await nextTick();
 
-    // mid2 re-evaluates because B is still active.
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend B — mid2 is now fully suspended.
-    topB.setSuspended(true);
+    // Unwatch B — mid2 is now fully deactivated.
+    suspend(topB);
     source.value = 3;
     await nextTick();
 
-    // No re-evaluation while fully suspended.
+    // No re-evaluation while fully deactivated.
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Unwatch both — signals should be cleaned up.
     unwatchA();
     unwatchB();
-    await sleep(20);
-
-    expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
   });
 
-  it('cleans cached values that are suspended and then unwatched', async () => {
+  it('cleans cached values that are unwatched and then rewatched', async () => {
     let evalCount = 0;
 
     const source = signal(1);
@@ -272,33 +252,25 @@ describe('Garbage Collection', () => {
     await nextTick();
 
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend and then remove the listener.
-    top.setSuspended(true);
+    // Unwatch and then remove the listener.
+    suspend(top);
     stop();
     await sleep(5);
 
-    // Signals should be garbage collected.
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
 
-    // Re-add a listener — should re-evaluate.
-    top.setSuspended(false);
+    // Re-add a listener — deps are preserved, cached values reused.
+    resume(top);
     const stop2 = top.addListener(() => {});
     await sleep(20);
 
-    expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+    expect(evalCount).toBe(1);
 
-    // Clean up.
     stop2();
-    await sleep(20);
-
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
   });
 
-  it('does not leak state across repeated suspend-unwatch cycles', async () => {
+  it('does not leak state across repeated unwatch-rewatch cycles', async () => {
     let evalCount = 0;
 
     const source = signal(1);
@@ -314,44 +286,41 @@ describe('Garbage Collection', () => {
       const stop = top.addListener(() => {});
       await nextTick();
 
-      expect(getSignalsMap(getGlobalScope()).size).toBe(2);
-
-      // Suspend
-      top.setSuspended(true);
-      await sleep(20);
-
-      expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+      expect(getLiveSignalCount()).toBe(2);
 
       // Unwatch
+      suspend(top);
+      await sleep(20);
+
+      expect(getLiveSignalCount()).toBe(2);
+
+      // Unwatch listener
       stop();
       await sleep(20);
 
-      expect(getSignalsMap(getGlobalScope()).size).toBe(0);
+      expect(getLiveSignalCount()).toBe(2);
 
       // Rewatch
       const stop2 = top.addListener(() => {});
       await sleep(20);
 
-      expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+      expect(getLiveSignalCount()).toBe(2);
 
       // Resume
-      top.setSuspended(false);
+      resume(top);
       await sleep(20);
-      expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+      expect(getLiveSignalCount()).toBe(2);
 
       // Unwatch
       stop2();
       await sleep(20);
-      expect(getSignalsMap(getGlobalScope()).size).toBe(0);
     }
 
-    // After many cycles, all signals should be properly cleaned up.
-    await sleep(50);
-
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
+    // After many cycles, no crashes or state corruption.
+    expect(evalCount).toBeGreaterThanOrEqual(1);
   });
 
-  it('shared dependency is preserved when consumers suspend and unwatch separately', async () => {
+  it('shared dependency is preserved when consumers unwatch separately', async () => {
     let evalCount = 0;
 
     const source = signal(1);
@@ -370,10 +339,9 @@ describe('Garbage Collection', () => {
     await nextTick();
 
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend and unwatch A. B is still active.
-    topA.setSuspended(true);
+    // Unwatch A. B is still active.
+    suspend(topA);
     unwatchA();
     await nextTick();
 
@@ -382,26 +350,16 @@ describe('Garbage Collection', () => {
     await nextTick();
 
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend and unwatch B. Now fully torn down.
-    topB.setSuspended(true);
+    // Unwatch B. Now fully torn down.
+    suspend(topB);
     unwatchB();
     await nextTick();
 
-    // Signals are still in the map right after deactivation — GC sweep
-    // hasn't run yet.
     expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
-
-    // Allow GC sweep to run — signals should now be cleaned up.
-    await sleep(50);
-
-    expect(evalCount).toBe(2);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
   });
 
-  it('does not garbage collect signals while suspended', async () => {
+  it('does not recompute unwatched signals when deps change', async () => {
     let evalCount = 0;
 
     const source = signal(1);
@@ -417,32 +375,30 @@ describe('Garbage Collection', () => {
     await nextTick();
 
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Suspend the watcher — signals should be preserved, not GC'd.
-    top.setSuspended(true);
+    // Unwatch the watcher — signals should be preserved.
+    suspend(top);
     await nextTick();
 
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+    expect(getLiveSignalCount()).toBe(2);
 
-    // Wait well beyond the GC sweep interval.
     await sleep(50);
 
-    // Signals should STILL be in the map — suspension keeps them alive.
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
+    // Signals should still be alive.
+    expect(getLiveSignalCount()).toBe(2);
 
-    // Changes while suspended should not trigger re-evaluation.
+    // Changes while unwatched should not trigger re-evaluation.
     source.value = 2;
     await nextTick();
 
     expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(2);
 
-    // Fully unwatch — now signals should be cleaned up.
+    // Resume — should re-evaluate with the new value.
+    resume(top);
+    await nextTick();
+
+    expect(evalCount).toBe(2);
+
     unwatchTop();
-    await sleep(20);
-
-    expect(evalCount).toBe(1);
-    expect(getSignalsMap(getGlobalScope()).size).toBe(0);
   });
 });

--- a/packages/signalium/src/__tests__/reactive-async.test.ts
+++ b/packages/signalium/src/__tests__/reactive-async.test.ts
@@ -699,7 +699,7 @@ describe('async computeds', () => {
         { desc: 'outer' },
       );
 
-      // Initial run with useDep1 = true
+      // Initial run with useDep2 = true
       const r1 = outer();
       await sleep(20);
       expect(r1.value).toBe(210);
@@ -707,7 +707,7 @@ describe('async computeds', () => {
       expect(dep2Count).toBe(1);
       expect(outerCount).toBe(1);
 
-      // Now change useDep2 to false - this dirties outer
+      // Change useDep2 to false — this dirties outer
       useDep2.value = false;
 
       const r2 = outer();
@@ -722,7 +722,7 @@ describe('async computeds', () => {
       // (it wasn't consumed this time and should have been disconnected)
       expect(dep2Count).toBe(1);
 
-      // Now change useDep2 to true again
+      // Change useDep2 to true again
       useDep2.value = true;
 
       const r3 = outer();
@@ -732,6 +732,9 @@ describe('async computeds', () => {
       expect(r3.isResolved).toBe(true);
       expect(r3.value).toBe(210); // 2*10 + 2*100
 
+      // dep2 was disconnected when useDep2 was false and marked Dirty, but
+      // since state2 hasn't changed, it revalidates to the same value.
+      // The recompute still happens because it was fully unwatched.
       expect(dep2Count).toBe(2);
     });
 

--- a/packages/signalium/src/__tests__/suspend-deactivation.test.ts
+++ b/packages/signalium/src/__tests__/suspend-deactivation.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest';
 import { reactive, watcher } from '../index.js';
+import { watchSignal, unwatchSignal } from '../internals/watch.js';
+import { schedulePull } from '../internals/scheduling.js';
+import { ReactiveSignal } from '../internals/reactive.js';
 import { nextTick, sleep } from './utils/async.js';
 
 function createDeferred<T>() {
@@ -8,20 +11,18 @@ function createDeferred<T>() {
   return { promise, resolve };
 }
 
-describe('suspend then resume before deactivation fires', () => {
+describe('unwatch then rewatch before deactivation fires', () => {
   /**
    * Exercises the path where:
    * 1. A watcher actively subscribes to a sync-wrapper-over-async signal
-   * 2. The watcher is suspended (schedules deactivation)
-   * 3. The watcher is immediately resumed (before deactivation fires)
+   * 2. The watcher is unwatched (schedules deactivation)
+   * 3. The watcher is immediately rewatched (before deactivation fires)
    * 4. The async value resolves
    *
-   * resumeSignal sees _isActive === true (deactivation hasn't run yet)
-   * so it skips reactivation AND does not cancel the pending deactivation.
-   * When the deactivation later fires, suspendCount is 0 so it takes the
-   * hard-deactivation path and damages deps' watchCounts.
+   * The rewatch via watchSignal must cancel the pending deactivation
+   * so deps' watchCounts are not damaged when the flush runs.
    */
-  test('signal resolves after suspend → resume with pending deactivation', async () => {
+  test('signal resolves after unwatch → rewatch with pending deactivation', async () => {
     const deferred = createDeferred<string>();
 
     const getAsyncValue = reactive(async () => {
@@ -33,10 +34,8 @@ describe('suspend then resume before deactivation fires', () => {
       return promise.isPending ? 'pending' : promise.value;
     });
 
-    // Create a watcher that mimics a React component
     const w = watcher(() => getWrappedValue());
 
-    // Step 1: actively subscribe
     let latestValue: unknown;
     const unsub = w.addListener(() => {
       latestValue = w.value;
@@ -44,15 +43,14 @@ describe('suspend then resume before deactivation fires', () => {
     await nextTick();
     expect(w.value).toBe('pending');
 
-    // Step 2: suspend (like SuspendSignalsProvider changing to true)
-    w.setSuspended(true);
+    // Step 2: unwatch (like PauseSignalsProvider changing to true)
+    unwatchSignal(w as unknown as ReactiveSignal<any, any>);
 
-    // Step 3: immediately resume (like a second component unsuspending)
-    // This is BEFORE the scheduled deactivation fires.
-    w.setSuspended(false);
+    // Step 3: immediately rewatch (before deactivation fires)
+    watchSignal(w as unknown as ReactiveSignal<any, any>);
+    schedulePull(w as unknown as ReactiveSignal<any, any>);
 
-    // Let the scheduled flush run — if deactivation isn't cancelled,
-    // it will damage deps
+    // Let the scheduled flush run — deactivation should have been cancelled
     await nextTick();
 
     // Step 4: resolve the async value

--- a/packages/signalium/src/internals/contexts.ts
+++ b/packages/signalium/src/internals/contexts.ts
@@ -1,6 +1,5 @@
 import { ReactiveSignal, ReactiveDefinition, createReactiveSignal } from './reactive.js';
 import { hashReactiveFn, hashValue } from './utils/hash.js';
-import { scheduleGcSweep } from './scheduling.js';
 import { getCurrentConsumer } from './consumer.js';
 import { Context } from '../types.js';
 import { dirtySignal } from './dirty.js';
@@ -82,8 +81,7 @@ export class SignalScope {
 
   private contexts: Record<symbol, unknown>;
   private children = new Map<number, SignalScope>();
-  private signals = new Map<number, ReactiveSignal<any, any>>();
-  private gcCandidates = new Set<ReactiveSignal<any, any>>();
+  private signals = new Map<number, WeakRef<ReactiveSignal<any, any>>>();
 
   setContexts(contexts: [ContextImpl<unknown>, unknown][]) {
     for (const [context, value] of contexts) {
@@ -119,48 +117,14 @@ export class SignalScope {
   get<T, Args extends unknown[]>(def: ReactiveDefinition<T, Args>, args: Args): ReactiveSignal<T, Args> {
     const paramKey = def.paramKey?.(...args);
     const key = hashReactiveFn(def.compute, paramKey ? [paramKey] : args);
-    let signal = this.signals.get(key) as ReactiveSignal<T, Args> | undefined;
+    let signal = this.signals.get(key)?.deref() as ReactiveSignal<T, Args> | undefined;
 
     if (signal === undefined) {
       signal = createReactiveSignal(def, args, key, this);
-      this.signals.set(key, signal);
+      this.signals.set(key, new WeakRef(signal));
     }
 
     return signal;
-  }
-
-  markForGc(signal: ReactiveSignal<any, any>) {
-    if (!this.gcCandidates.has(signal)) {
-      this.gcCandidates.add(signal);
-      scheduleGcSweep(this);
-    }
-  }
-
-  removeFromGc(signal: ReactiveSignal<any, any>) {
-    this.gcCandidates.delete(signal);
-
-    const { key } = signal;
-
-    // if the signal has a key, add it back to the signals map so we can re-use it
-    if (key) {
-      this.signals.set(key, signal);
-    }
-  }
-
-  forceGc(signal: ReactiveSignal<any, any>) {
-    this.signals.delete(signal.key!);
-  }
-
-  sweepGc() {
-    const signals = this.signals;
-
-    for (const signal of this.gcCandidates) {
-      if (signal.watchCount === 0) {
-        signals.delete(signal.key!);
-      }
-    }
-
-    this.gcCandidates = new Set();
   }
 }
 
@@ -231,7 +195,6 @@ export const getScopeOwner = (obj: object): SignalScope => {
 
 // ======= Test Helper =======
 
-export function forceGc(_signal: object) {
-  const signal = _signal as ReactiveSignal<any, any>;
-  signal.scope?.forceGc(signal);
+export function getSignalsMap(scope: SignalScope) {
+  return (scope as any).signals as Map<number, WeakRef<ReactiveSignal<any, any>>>;
 }

--- a/packages/signalium/src/internals/dirty.ts
+++ b/packages/signalium/src/internals/dirty.ts
@@ -31,7 +31,7 @@ function propagateDirty(signal: ReactiveSignal<any, any>) {
 
     // else do nothing, only schedule if connected
   } else {
-    if (signal._isListener && !signal._isSuspendedListener) {
+    if (signal._isListener && signal.watchCount > 0) {
       schedulePull(signal);
     }
 

--- a/packages/signalium/src/internals/get.ts
+++ b/packages/signalium/src/internals/get.ts
@@ -3,7 +3,7 @@ import { createPromise, isReactivePromise, ReactivePromiseImpl } from './async.j
 import { getCurrentConsumer, setCurrentConsumer } from './consumer.js';
 import { createEdge, Edge, EdgeType } from './edge.js';
 import { generatorResultToPromiseWithConsumer } from './generators.js';
-import { isRelay, ReactiveFnState, ReactiveSignal } from './reactive.js';
+import { ReactiveFnState, isRelay, ReactiveSignal } from './reactive.js';
 import { scheduleListeners, scheduleTracer } from './scheduling.js';
 import { getTracerProxy, SignalType, TracerEventType } from './trace.js';
 import { isGeneratorResult, isPromise } from './utils/type-utils.js';
@@ -31,7 +31,7 @@ export function getSignal<T, Args extends unknown[]>(signal: ReactiveSignal<T, A
         }
 
         if (currentConsumer.watchCount > 0) {
-          watchSignal(signal, currentConsumer._isSuspended);
+          watchSignal(signal);
         }
       }
 
@@ -206,13 +206,18 @@ export function runSignal(signal: ReactiveSignal<any, any[]>) {
 }
 
 export function disconnectSignal(signal: ReactiveSignal<any, any>, computedCount: number = signal.computedCount) {
-  const { ref, deps, _isSuspended: isSuspended } = signal;
+  const { ref, deps } = signal;
 
   for (const [dep, edge] of deps) {
     if (edge.consumedAt !== computedCount) {
-      unwatchSignal(dep, isSuspended);
+      unwatchSignal(dep);
       dep.subs.delete(ref);
       deps.delete(dep);
+      // Mark disconnected dep as Dirty so it revalidates when re-read.
+      // Its subscription chain is broken and it may miss notifications.
+      if (dep._state < ReactiveFnState.Dirty) {
+        dep._state = ReactiveFnState.Dirty;
+      }
     }
   }
 }

--- a/packages/signalium/src/internals/reactive.ts
+++ b/packages/signalium/src/internals/reactive.ts
@@ -1,4 +1,3 @@
-import WeakRef from './weakref.js';
 import { Tracer, getTracerProxy, TracerMeta } from './trace.js';
 import { ReactiveValue, Equals, ReactiveOptions } from '../types.js';
 import { getUnknownSignalFnName } from './utils/debug-name.js';
@@ -9,7 +8,7 @@ import { cancelPull, schedulePull } from './scheduling.js';
 import { hashValue } from './utils/hash.js';
 import { stringifyValue } from './utils/stringify.js';
 import { Callback } from './callback.js';
-import { resumeSignal, suspendSignal, unwatchSignal, watchSignal } from './watch.js';
+import { unwatchSignal, watchSignal } from './watch.js';
 import { equalsFrom } from './utils/equals.js';
 import { dirtySignal } from './dirty.js';
 
@@ -41,9 +40,8 @@ export const enum ReactiveFnFlags {
   // Properties
   isRelay = 0b1000,
   isListener = 0b10000,
-  isSuspendedListener = 0b100000,
-  isActive = 0b1000000,
-  isLazy = 0b10000000,
+  isActive = 0b100000,
+  isLazy = 0b1000000,
 }
 
 let ID = 0;
@@ -117,7 +115,6 @@ export class ReactiveSignal<T, Args extends unknown[]> {
   computedCount: number = 0;
 
   watchCount: number = 0;
-  suspendCount: number = 0;
 
   key: SignalId | undefined;
   args: Args;
@@ -160,15 +157,6 @@ export class ReactiveSignal<T, Args extends unknown[]> {
 
   get _isListener() {
     return (this.flags & ReactiveFnFlags.isListener) !== 0;
-  }
-
-  get _isSuspendedListener() {
-    return (this.flags & ReactiveFnFlags.isSuspendedListener) !== 0;
-  }
-
-  get _isSuspended() {
-    const { watchCount, suspendCount } = this;
-    return watchCount > 0 && watchCount === suspendCount;
   }
 
   get _isActive() {
@@ -228,14 +216,11 @@ export class ReactiveSignal<T, Args extends unknown[]> {
       }
 
       if (!this._isListener) {
-        watchSignal(this, this._isSuspended);
+        watchSignal(this);
         this.flags |= ReactiveFnFlags.isListener;
       }
 
-      // Skip the initial pull when this listener is registered under a
-      // suspended context — otherwise `checkAndRunListeners` would fire the
-      // React listener on mount even though we're suspended.
-      if (!this._isSuspendedListener) {
+      if (this.watchCount > 0) {
         schedulePull(this);
       }
 
@@ -248,7 +233,7 @@ export class ReactiveSignal<T, Args extends unknown[]> {
 
         if (current.size === 0) {
           cancelPull(this);
-          unwatchSignal(this, this._isSuspended);
+          unwatchSignal(this);
           this.flags &= ~ReactiveFnFlags.isListener;
           this.listeners.updatedAt = 0;
         }
@@ -259,45 +244,17 @@ export class ReactiveSignal<T, Args extends unknown[]> {
   // This method is used in React hooks specifically. It returns a bound add method
   // that is cached to avoid creating a new one on each call, and it eagerly sets
   // the listener as watched so that relays that are accessed will be activated.
-  addListenerLazy() {
+  addListenerLazy(watch = true) {
     if (!this._isListener) {
-      watchSignal(this, this._isSuspended);
+      if (watch) {
+        watchSignal(this);
+      }
       this.flags |= ReactiveFnFlags.isListener;
     }
 
     return this.listeners.cachedBoundAdd;
   }
 
-  setSuspended(suspended: boolean) {
-    const { flags } = this;
-    const isListener = (flags & ReactiveFnFlags.isListener) !== 0;
-    const isSuspendedListener = (flags & ReactiveFnFlags.isSuspendedListener) !== 0;
-
-    if (suspended && !isSuspendedListener) {
-      this.flags = flags | ReactiveFnFlags.isSuspendedListener;
-
-      if (isListener) {
-        suspendSignal(this);
-      }
-    } else if (!suspended && isSuspendedListener) {
-      this.flags = flags & ~ReactiveFnFlags.isSuspendedListener;
-
-      if (isListener) {
-        resumeSignal(this);
-      }
-    }
-  }
-
-  reset() {
-    this.flags = (this.def.isRelay ? ReactiveFnFlags.isRelay : 0) | ReactiveFnState.Dirty;
-    this.dirtyHead = undefined;
-    this.updatedCount = 0;
-    this.computedCount = 0;
-    this.deps = new Map();
-    this.subs = new Map();
-    this.watchCount = 0;
-    this.suspendCount = 0;
-  }
 }
 
 export const runListeners = (signal: ReactiveSignal<any, any>) => {

--- a/packages/signalium/src/internals/scheduling.ts
+++ b/packages/signalium/src/internals/scheduling.ts
@@ -6,18 +6,12 @@ import { runListeners as runStateListeners } from './signal.js';
 import type { Tracer } from './trace.js';
 import { deactivateSignal } from './watch.js';
 import { StateSignal } from './signal.js';
-import { SignalScope } from './contexts.js';
-
-// Determine once at startup which scheduling function to use for GC
-const scheduleIdleCallback =
-  typeof requestIdleCallback === 'function' ? requestIdleCallback : (cb: () => void) => _scheduleFlush(cb);
 
 let PENDING_PULLS: Set<ReactiveSignal<any, any>> = new Set();
 let PENDING_ASYNC_PULLS: ReactiveSignal<any, any>[] = [];
 let PENDING_DEACTIVE = new Set<ReactiveSignal<any, any>>();
 let PENDING_LISTENERS: (ReactiveSignal<any, any> | StateSignal<any>)[] = [];
 let PENDING_TRACERS: Tracer[] | undefined = IS_DEV ? [] : undefined;
-let PENDING_GC = new Set<SignalScope>();
 
 const microtask = () => Promise.resolve();
 
@@ -54,7 +48,6 @@ export const scheduleDeactivate = (signal: ReactiveSignal<any, any>) => {
 };
 
 export const cancelDeactivate = (signal: ReactiveSignal<any, any>) => {
-  signal.scope?.removeFromGc(signal);
   PENDING_DEACTIVE.delete(signal);
 };
 
@@ -68,20 +61,6 @@ export const scheduleTracer = (tracer: Tracer) => {
     PENDING_TRACERS!.push(tracer);
     scheduleFlush(flushWatchers);
   }
-};
-
-export const scheduleGcSweep = (scope: SignalScope) => {
-  PENDING_GC.add(scope);
-
-  if (PENDING_GC.size > 1) return;
-
-  scheduleIdleCallback(() => {
-    for (const scope of PENDING_GC) {
-      scope.sweepGc();
-    }
-
-    PENDING_GC.clear();
-  });
 };
 
 const flushWatchers = async () => {

--- a/packages/signalium/src/internals/watch.ts
+++ b/packages/signalium/src/internals/watch.ts
@@ -2,27 +2,10 @@ import { ReactiveSignal, isRelay } from './reactive.js';
 import { checkSignal } from './get.js';
 import { cancelDeactivate, scheduleDeactivate } from './scheduling.js';
 
-export function watchSignal(signal: ReactiveSignal<any, any>, parentIsSuspended: boolean): void {
-  if (parentIsSuspended) {
-    watchSuspendedSignal(signal);
-  } else {
-    watchActiveSignal(signal);
-  }
-}
-
-export function unwatchSignal(signal: ReactiveSignal<any, any>, parentIsSuspended: boolean): void {
-  if (parentIsSuspended) {
-    unwatchSuspendedSignal(signal);
-  } else {
-    unwatchActiveSignal(signal);
-  }
-}
-
-function watchActiveSignal(signal: ReactiveSignal<any, any>): void {
+export function watchSignal(signal: ReactiveSignal<any, any>): void {
   const { watchCount } = signal;
-  const newWatchCount = watchCount + 1;
 
-  signal.watchCount = newWatchCount;
+  signal.watchCount = watchCount + 1;
   cancelDeactivate(signal);
 
   if (signal._isActive) {
@@ -30,13 +13,13 @@ function watchActiveSignal(signal: ReactiveSignal<any, any>): void {
   }
 
   for (const dep of signal.deps.keys()) {
-    watchActiveSignal(dep);
+    watchSignal(dep);
   }
 
   activateSignal(signal);
 }
 
-function unwatchActiveSignal(signal: ReactiveSignal<any, any>) {
+export function unwatchSignal(signal: ReactiveSignal<any, any>) {
   const { watchCount } = signal;
   const newWatchCount = Math.max(watchCount - 1, 0);
 
@@ -47,116 +30,29 @@ function unwatchActiveSignal(signal: ReactiveSignal<any, any>) {
   }
 }
 
-function watchSuspendedSignal(signal: ReactiveSignal<any, any>): void {
-  const { watchCount, suspendCount } = signal;
-
-  const newWatchCount = watchCount + 1;
-  const newSuspendCount = suspendCount + 1;
-
-  signal.watchCount = newWatchCount;
-  signal.suspendCount = newSuspendCount;
-
-  cancelDeactivate(signal);
-
-  // If the original watch count was 0, we need to propagate the watch + suspend
-  // to dependencies because we are becoming watched. BUT, we don't need to
-  // activate, because the signal is not changing state in this case. It is
-  // moving from unwatched -> suspended, which means we _do not_ activate.
-  if (watchCount === 0) {
-    for (const dep of signal.deps.keys()) {
-      watchSuspendedSignal(dep);
-    }
-  }
-}
-
-function unwatchSuspendedSignal(signal: ReactiveSignal<any, any>): void {
-  const { watchCount, suspendCount } = signal;
-
-  const newWatchCount = Math.max(watchCount - 1, 0);
-  const newSuspendCount = Math.max(suspendCount - 1, 0);
-
-  signal.watchCount = newWatchCount;
-  signal.suspendCount = newSuspendCount;
-
-  // We _do_ need to schedule deactivate if we are no longer watched, because
-  // the signal is now becoming inactive.
-  if (newWatchCount === 0) {
-    scheduleDeactivate(signal);
-  }
-}
-
-export function resumeSignal(signal: ReactiveSignal<any, any>): void {
-  const { watchCount, suspendCount } = signal;
-  const newSuspendCount = Math.max(suspendCount - 1, 0);
-
-  signal.suspendCount = newSuspendCount;
-  cancelDeactivate(signal);
-
-  if (watchCount > 0 && !signal._isActive) {
-    for (const dep of signal.deps.keys()) {
-      resumeSignal(dep);
-    }
-
-    activateSignal(signal);
-  }
-}
-
-export function suspendSignal(signal: ReactiveSignal<any, any>): void {
-  const { watchCount, suspendCount } = signal;
-  const newSuspendCount = suspendCount + 1;
-
-  signal.suspendCount = newSuspendCount;
-
-  if (watchCount > 0 && newSuspendCount === watchCount) {
-    scheduleDeactivate(signal);
-  }
-}
-
-function activateSignal(signal: ReactiveSignal<any, any>): void {
-  // If signal is being watched again, remove from GC candidates and add back to scope
-  signal.scope?.removeFromGc(signal);
+export function activateSignal(signal: ReactiveSignal<any, any>): void {
   cancelDeactivate(signal);
 
   signal._isActive = true;
 
   if (isRelay(signal)) {
-    // Bootstrap the relay
     checkSignal(signal);
   }
 }
 
 export function deactivateSignal(signal: ReactiveSignal<any, any>) {
-  const { watchCount, suspendCount } = signal;
-
   signal._isActive = false;
-  const isSuspending = watchCount > 0 && suspendCount === watchCount;
 
   for (const dep of signal.deps.keys()) {
-    const { watchCount: depWatchCount, suspendCount: depSuspendCount } = dep;
+    const newWatchCount = Math.max(dep.watchCount - 1, 0);
+    dep.watchCount = newWatchCount;
 
-    if (isSuspending) {
-      const newSuspendCount = (dep.suspendCount = depSuspendCount + 1);
-
-      if (newSuspendCount === depWatchCount) {
-        deactivateSignal(dep);
-      }
-    } else {
-      const newWatchCount = (dep.watchCount = depWatchCount - 1);
-
-      if (newWatchCount === 0) {
-        deactivateSignal(dep);
-      }
+    if (newWatchCount === 0) {
+      deactivateSignal(dep);
     }
   }
 
   if (isRelay(signal)) {
-    // teardown the relay
     signal._value?.();
-  }
-
-  // If watchCount is now zero, mark the signal for GC
-  if (watchCount === 0) {
-    signal.scope?.markForGc(signal);
-    signal.reset();
   }
 }

--- a/packages/signalium/src/internals/weakref.ts
+++ b/packages/signalium/src/internals/weakref.ts
@@ -1,9 +1,0 @@
-class WeakRefPolyfill<T extends WeakKey> {
-  constructor(private value: T) {}
-
-  deref(): T {
-    return this.value;
-  }
-}
-
-export default typeof WeakRef === 'function' ? WeakRef : (WeakRefPolyfill as unknown as WeakRefConstructor);

--- a/packages/signalium/src/react/__tests__/async-sync-wrapper-cold-start.test.tsx
+++ b/packages/signalium/src/react/__tests__/async-sync-wrapper-cold-start.test.tsx
@@ -5,7 +5,7 @@ import { reactive } from 'signalium';
 import { render } from 'vitest-browser-react';
 import { describe, expect, test } from 'vitest';
 import { sleep } from '../../__tests__/utils/async.js';
-import { ContextProvider, SuspendSignalsProvider, useReactive } from 'signalium/react';
+import { ContextProvider, PauseSignalsProvider, useReactive } from 'signalium/react';
 
 /**
  * Creates a deferred promise that can be resolved from the test body.
@@ -189,9 +189,9 @@ describe('React > sync wrapper over async signal', () => {
 
       return (
         <ContextProvider contexts={[]}>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <Consumer />
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button
             data-testid="suspend-and-resume"
             onClick={() => {

--- a/packages/signalium/src/react/__tests__/pause-signals-value-preservation.test.tsx
+++ b/packages/signalium/src/react/__tests__/pause-signals-value-preservation.test.tsx
@@ -1,14 +1,14 @@
 import { describe, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { signal, reactive, relay } from 'signalium';
-import { useReactive, SuspendSignalsProvider } from 'signalium/react';
+import { useReactive, PauseSignalsProvider } from 'signalium/react';
 import React, { useState } from 'react';
 import { userEvent } from '@vitest/browser/context';
 import { sleep } from '../../__tests__/utils/async.js';
 import { createRenderCounter } from './utils.js';
 import component from '../component.js';
 
-describe('React > Suspend Signals > Value Preservation', () => {
+describe('React > Pause Signals > Value Preservation', () => {
   test('async reactive value is preserved across suspend/resume cycle', async () => {
     const input = signal('Hello');
 
@@ -46,9 +46,9 @@ describe('React > Suspend Signals > Value Preservation', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <Inner />
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button onClick={() => setSuspended(s => !s)}>Toggle</button>
         </div>
       );
@@ -119,9 +119,9 @@ describe('React > Suspend Signals > Value Preservation', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <Inner />
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button onClick={() => setSuspended(s => !s)}>Toggle</button>
         </div>
       );
@@ -178,9 +178,9 @@ describe('React > Suspend Signals > Value Preservation', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <Inner />
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button data-testid="toggle" onClick={() => setSuspended(s => !s)}>
             Toggle
           </button>
@@ -227,7 +227,7 @@ describe('React > Suspend Signals > Value Preservation', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>{mounted ? <Inner /> : null}</SuspendSignalsProvider>
+          <PauseSignalsProvider value={suspended}>{mounted ? <Inner /> : null}</PauseSignalsProvider>
           <button data-testid="toggle-suspend" onClick={() => setSuspended(s => !s)}>
             Toggle Suspend
           </button>

--- a/packages/signalium/src/react/__tests__/pause-signals.test.tsx
+++ b/packages/signalium/src/react/__tests__/pause-signals.test.tsx
@@ -1,15 +1,15 @@
 import { describe, expect, test, vi } from 'vitest';
 import { render } from 'vitest-browser-react';
 import { signal, reactive, relay } from 'signalium';
-import { useReactive, SuspendSignalsProvider } from 'signalium/react';
+import { useReactive, PauseSignalsProvider } from 'signalium/react';
 import React, { useState } from 'react';
 import { userEvent } from '@vitest/browser/context';
 import { sleep } from '../../__tests__/utils/async.js';
 import { createRenderCounter } from './utils.js';
 import component from '../component.js';
 
-describe('React > Suspend Signals', () => {
-  test('basic suspension - signals do not trigger re-renders when suspended', async () => {
+describe('React > Pause Signals', () => {
+  test('basic pausing - signals do not trigger re-renders when paused', async () => {
     const text = signal('Hello');
 
     function Component(): React.ReactNode {
@@ -17,9 +17,9 @@ describe('React > Suspend Signals', () => {
     }
 
     const { getByText } = render(
-      <SuspendSignalsProvider value={true}>
+      <PauseSignalsProvider value={true}>
         <Component />
-      </SuspendSignalsProvider>,
+      </PauseSignalsProvider>,
     );
 
     await expect.element(getByText('Hello')).toBeInTheDocument();
@@ -39,9 +39,9 @@ describe('React > Suspend Signals', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <div data-testid="content">{useReactive(() => text.value)}</div>
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button onClick={() => setDisabled(!suspended)}>Toggle Disabled</button>
         </div>
       );
@@ -85,12 +85,12 @@ describe('React > Suspend Signals', () => {
     }
 
     const { getByTestId } = render(
-      <SuspendSignalsProvider value={true}>
+      <PauseSignalsProvider value={true}>
         <Outer />
-        <SuspendSignalsProvider value={false}>
+        <PauseSignalsProvider value={false}>
           <Inner />
-        </SuspendSignalsProvider>
-      </SuspendSignalsProvider>,
+        </PauseSignalsProvider>
+      </PauseSignalsProvider>,
     );
 
     await expect.element(getByTestId('outer')).toHaveTextContent('Hello');
@@ -106,15 +106,15 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByTestId('inner')).toHaveTextContent('World');
   });
 
-  test('component function respects suspended context', async () => {
+  test('component function respects paused context', async () => {
     const text = signal('Hello');
 
     const Component = component(() => <div>{text.value}</div>);
 
     const { getByText } = render(
-      <SuspendSignalsProvider value={true}>
+      <PauseSignalsProvider value={true}>
         <Component />
-      </SuspendSignalsProvider>,
+      </PauseSignalsProvider>,
     );
 
     await expect.element(getByText('Hello')).toBeInTheDocument();
@@ -124,7 +124,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByText('Hello')).toBeInTheDocument();
   });
 
-  test('useReactive with signals respects suspended context', async () => {
+  test('useReactive with signals respects paused context', async () => {
     const count = signal(0);
 
     function Component(): React.ReactNode {
@@ -132,9 +132,9 @@ describe('React > Suspend Signals', () => {
     }
 
     const { getByText } = render(
-      <SuspendSignalsProvider value={true}>
+      <PauseSignalsProvider value={true}>
         <Component />
-      </SuspendSignalsProvider>,
+      </PauseSignalsProvider>,
     );
 
     await expect.element(getByText('0')).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByText('0')).toBeInTheDocument();
   });
 
-  test('useReactive with reactive functions respects suspended context', async () => {
+  test('useReactive with reactive functions respects paused context', async () => {
     const text = signal('Hello');
     const derived = reactive(() => `${text.value}, World`);
 
@@ -155,9 +155,9 @@ describe('React > Suspend Signals', () => {
     }
 
     const { getByText } = render(
-      <SuspendSignalsProvider value={true}>
+      <PauseSignalsProvider value={true}>
         <Component />
-      </SuspendSignalsProvider>,
+      </PauseSignalsProvider>,
     );
 
     await expect.element(getByText('Hello, World')).toBeInTheDocument();
@@ -166,7 +166,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByText('Hello, World')).toBeInTheDocument();
   });
 
-  test('value retention - suspended signals maintain their last value', async () => {
+  test('value retention - paused signals maintain their last value', async () => {
     const count = signal(0);
 
     function Component(): React.ReactNode {
@@ -174,9 +174,9 @@ describe('React > Suspend Signals', () => {
 
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <div data-testid="count">{useReactive(() => count.value)}</div>
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
           <button onClick={() => setDisabled(!suspended)}>Toggle</button>
         </div>
       );
@@ -209,7 +209,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByTestId('count')).toHaveTextContent('5');
   });
 
-  test('reactive promises respect suspended context', async () => {
+  test('reactive promises respect paused context', async () => {
     const value = signal('Hello');
 
     const derived = reactive(async () => {
@@ -220,9 +220,9 @@ describe('React > Suspend Signals', () => {
 
     const Component = component(({ suspended }: { suspended: boolean }) => {
       return (
-        <SuspendSignalsProvider value={suspended}>
+        <PauseSignalsProvider value={suspended}>
           <Inner />
-        </SuspendSignalsProvider>
+        </PauseSignalsProvider>
       );
     });
 
@@ -259,7 +259,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByText('Hello, World')).toBeInTheDocument();
   });
 
-  test('relays respect suspended context', async () => {
+  test('relays respect paused context', async () => {
     const content = signal('World');
 
     const derived = reactive(() => {
@@ -283,10 +283,10 @@ describe('React > Suspend Signals', () => {
       const [suspended, setDisabled] = useState(false);
       return (
         <div>
-          <SuspendSignalsProvider value={suspended}>
+          <PauseSignalsProvider value={suspended}>
             <Inner />
             <button onClick={() => setDisabled(!suspended)}>Toggle</button>
-          </SuspendSignalsProvider>
+          </PauseSignalsProvider>
         </div>
       );
     };
@@ -313,7 +313,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByText('Hello, Universe')).toBeInTheDocument();
   });
 
-  test('multiple components with different suspended states', async () => {
+  test('multiple components with different paused states', async () => {
     const count = signal(0);
 
     const ComponentA = () => <div data-testid="a">{useReactive(() => count.value)}</div>;
@@ -322,12 +322,12 @@ describe('React > Suspend Signals', () => {
 
     const { getByTestId } = render(
       <div>
-        <SuspendSignalsProvider value={true}>
+        <PauseSignalsProvider value={true}>
           <ComponentA />
-        </SuspendSignalsProvider>
-        <SuspendSignalsProvider value={false}>
+        </PauseSignalsProvider>
+        <PauseSignalsProvider value={false}>
           <ComponentB />
-        </SuspendSignalsProvider>
+        </PauseSignalsProvider>
         <ComponentC />
       </div>,
     );
@@ -346,7 +346,7 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByTestId('c')).toHaveTextContent('1');
   });
 
-  test('disabling does not prevent new subscriptions', async () => {
+  test('pausing does not prevent new subscriptions', async () => {
     const count = signal(0);
 
     const Child = () => <div data-testid="content">{useReactive(() => count.value)}</div>;
@@ -355,12 +355,12 @@ describe('React > Suspend Signals', () => {
       const [show, setShow] = useState(false);
 
       return (
-        <SuspendSignalsProvider value={true}>
+        <PauseSignalsProvider value={true}>
           <div>
             {show && <Child />}
             <button onClick={() => setShow(true)}>Show</button>
           </div>
-        </SuspendSignalsProvider>
+        </PauseSignalsProvider>
       );
     };
 
@@ -377,15 +377,90 @@ describe('React > Suspend Signals', () => {
     await expect.element(getByTestId('content')).toHaveTextContent('0');
   });
 
-  test('render count is not affected when signals update while suspended', async () => {
+  test('relay is not activated when component mounts inside an already-paused provider', async () => {
+    let relayActivateCount = 0;
+
+    const derived = reactive(() => {
+      return relay<string>(state => {
+        relayActivateCount++;
+        state.value = 'activated';
+      });
+    });
+
+    function Inner(): React.ReactNode {
+      const d = useReactive(() => derived());
+      return <div data-testid="content">{d.isPending ? 'pending' : d.value}</div>;
+    }
+
+    function Wrapper(): React.ReactNode {
+      const [show, setShow] = useState(false);
+
+      return (
+        <PauseSignalsProvider value={true}>
+          {show && <Inner />}
+          <button onClick={() => setShow(true)}>Mount</button>
+        </PauseSignalsProvider>
+      );
+    }
+
+    const { getByText, getByTestId } = render(<Wrapper />);
+
+    // Mount the component inside the already-suspended provider
+    await userEvent.click(getByText('Mount'));
+
+    // The component renders with the initial value, but the relay
+    // should NOT have been activated since the provider is suspended.
+    await sleep(50);
+    expect(relayActivateCount).toBe(0);
+    await expect.element(getByTestId('content')).toHaveTextContent('pending');
+  });
+
+  test('toggling pause does not cause re-renders when signals have not changed', async () => {
+    const count = signal(0);
+    const Child = createRenderCounter(() => <div data-testid="content">{useReactive(() => count.value)}</div>);
+    const MemoChild = React.memo(Child);
+
+    function Wrapper(): React.ReactNode {
+      const [suspended, setSuspended] = useState(false);
+
+      return (
+        <div>
+          <PauseSignalsProvider value={suspended}>
+            <MemoChild />
+          </PauseSignalsProvider>
+          <button onClick={() => setSuspended(s => !s)}>Toggle</button>
+        </div>
+      );
+    }
+
+    const { getByText, getByTestId } = render(<Wrapper />);
+
+    await expect.element(getByTestId('content')).toHaveTextContent('0');
+    const afterMount = Child.renderCount;
+
+    // Suspend
+    await userEvent.click(getByText('Toggle'));
+    await sleep(50);
+
+    // Resume — signal hasn't changed and the child is memoized, so
+    // the context change is fully absorbed by the provider. Zero
+    // extra renders on the child.
+    await userEvent.click(getByText('Toggle'));
+    await sleep(50);
+
+    expect(Child.renderCount).toBe(afterMount);
+    await expect.element(getByTestId('content')).toHaveTextContent('0');
+  });
+
+  test('render count is not affected when signals update while paused', async () => {
     const count = signal(0);
     const Child = createRenderCounter(() => <div>{useReactive(() => count.value)}</div>);
 
     const Component = () => {
       return (
-        <SuspendSignalsProvider value={true}>
+        <PauseSignalsProvider value={true}>
           <Child />
-        </SuspendSignalsProvider>
+        </PauseSignalsProvider>
       );
     };
 

--- a/packages/signalium/src/react/async-component.ts
+++ b/packages/signalium/src/react/async-component.ts
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef, useSyncExternalStore } from 'react';
+import React, { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import type * as ReactTypes from 'react';
 import { getCurrentConsumer, setCurrentConsumer } from '../internals/consumer.js';
 import { createReactiveSignal, ReactiveSignal } from '../internals/reactive.js';
@@ -7,7 +7,7 @@ import { isReactivePromise, ReactivePromiseImpl } from '../internals/async.js';
 import { hashValue } from '../internals/utils/hash.js';
 import { isPromise, isThennable } from '../internals/utils/type-utils.js';
 import { useScope } from './context.js';
-import { useSignalsSuspended } from './suspend-signals-context.js';
+import { usePauseSignalsManager } from './pause-signals-context.js';
 
 /**
  * Remembers settled outcomes for yielded thenables so synchronous replay can inject
@@ -146,7 +146,7 @@ export function createAsyncComponentWrapper<P extends object>(
 ): (props: P) => ReactTypes.ReactNode {
   const Inner = (props: P) => {
     const scope = useScope();
-    const suspended = useSignalsSuspended();
+    const manager = usePauseSignalsManager();
 
     const fnSignalRef = useRef<ReactiveSignal<ReactTypes.ReactNode | ReactTypes.ReactNode[] | null, []> | undefined>(
       undefined,
@@ -172,10 +172,15 @@ export function createAsyncComponentWrapper<P extends object>(
       fnSignalRef.current = sig = owned;
     }
 
-    sig.setSuspended(suspended);
+    const watch = !manager?.paused;
+    manager?.register(sig);
+
+    useEffect(() => {
+      return () => manager?.unregister(sig!);
+    }, [manager, sig]);
 
     useSyncExternalStore(
-      sig.addListenerLazy(),
+      sig.addListenerLazy(watch),
       () => sig!.updatedCount,
       () => sig!.updatedCount,
     );

--- a/packages/signalium/src/react/component.tsx
+++ b/packages/signalium/src/react/component.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { useMemo, useRef, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import type { ReactNode } from 'react';
 import { useScope } from './context.js';
-import { useSignalsSuspended } from './suspend-signals-context.js';
+import { usePauseSignalsManager } from './pause-signals-context.js';
 import { setRequestScopeGetter, SignalScope } from '../internals/contexts.js';
 import { createReactiveSignal, ReactiveSignal } from '../internals/reactive.js';
 import { runSignal } from '../internals/get.js';
@@ -75,7 +75,7 @@ export default function component<Props extends object>(
 
   const Component = (props: Props) => {
     const scope = useScope();
-    const suspended = useSignalsSuspended();
+    const manager = usePauseSignalsManager();
 
     const fnSignalRef = useRef<ReactiveSignal<ComponentRender, []> | undefined>(undefined);
     const propsRef = useRef<Props>(props);
@@ -100,13 +100,15 @@ export default function component<Props extends object>(
       fnSignalRef.current = signal = created;
     }
 
-    signal.setSuspended(suspended);
+    const watch = !manager?.paused;
+    manager?.register(signal);
 
-    // We always want to re-render when the signal is updated, regardless of
-    // whether or not the result changed. This is because the signal is lazy,
-    // so it will not be updated until the next render.
+    useEffect(() => {
+      return () => manager?.unregister(signal!);
+    }, [manager, signal]);
+
     useSyncExternalStore(
-      signal.addListenerLazy(),
+      signal.addListenerLazy(watch),
       () => signal.updatedCount,
       () => signal.updatedCount,
     );

--- a/packages/signalium/src/react/index.ts
+++ b/packages/signalium/src/react/index.ts
@@ -9,5 +9,4 @@ export {
 export { useContext } from './context.js';
 export { useSignal } from './use-signal.js';
 export { useReactive, useReactiveShallow, useReactiveDeep } from './use-reactive.js';
-export { SuspendSignalsProvider } from './suspend-signals-context.js';
-export { useSignalsSuspended } from './suspend-signals-context.js';
+export { PauseSignalsProvider } from './pause-signals-context.js';

--- a/packages/signalium/src/react/pause-signals-context.ts
+++ b/packages/signalium/src/react/pause-signals-context.ts
@@ -1,0 +1,65 @@
+import React, { createContext, useContext, useEffect, useRef } from 'react';
+import { ReactiveSignal } from '../internals/reactive.js';
+import { watchSignal, unwatchSignal } from '../internals/watch.js';
+import { schedulePull } from '../internals/scheduling.js';
+
+class PauseSignalsManager {
+  private signals = new Set<ReactiveSignal<any, any>>();
+  private _paused: boolean;
+
+  constructor(initialPaused: boolean) {
+    this._paused = initialPaused;
+  }
+
+  get paused() {
+    return this._paused;
+  }
+
+  register(signal: ReactiveSignal<any, any>) {
+    this.signals.add(signal);
+  }
+
+  unregister(signal: ReactiveSignal<any, any>) {
+    this.signals.delete(signal);
+  }
+
+  setPaused(value: boolean) {
+    if (value === this._paused) return;
+    this._paused = value;
+    for (const signal of this.signals) {
+      if (value) {
+        unwatchSignal(signal);
+      } else {
+        watchSignal(signal);
+        schedulePull(signal);
+      }
+    }
+  }
+}
+
+const PauseSignalsManagerContext = createContext<PauseSignalsManager | null>(null);
+
+export function PauseSignalsProvider({
+  value,
+  children,
+}: {
+  value: boolean;
+  children: React.ReactNode;
+}) {
+  const managerRef = useRef<PauseSignalsManager>(null);
+  if (managerRef.current === null) {
+    managerRef.current = new PauseSignalsManager(value);
+  }
+
+  const manager = managerRef.current;
+
+  useEffect(() => {
+    manager.setPaused(value);
+  }, [manager, value]);
+
+  return React.createElement(PauseSignalsManagerContext.Provider, { value: manager }, children);
+}
+
+export function usePauseSignalsManager(): PauseSignalsManager | null {
+  return useContext(PauseSignalsManagerContext);
+}

--- a/packages/signalium/src/react/suspend-signals-context.ts
+++ b/packages/signalium/src/react/suspend-signals-context.ts
@@ -1,9 +1,0 @@
-import { createContext, useContext } from 'react';
-
-const SuspendSignalsContext = createContext<boolean>(false);
-
-export const SuspendSignalsProvider = SuspendSignalsContext.Provider;
-
-export function useSignalsSuspended(): boolean {
-  return useContext(SuspendSignalsContext);
-}

--- a/packages/signalium/src/react/use-reactive.ts
+++ b/packages/signalium/src/react/use-reactive.ts
@@ -1,24 +1,29 @@
-import { useRef, useSyncExternalStore } from 'react';
+import { useEffect, useRef, useSyncExternalStore } from 'react';
 import { ReactiveValue } from '../types.js';
 import { getReactiveFnAndDefinition, reactiveSignal } from '../internals/core-api.js';
 import { getCurrentConsumer } from '../internals/consumer.js';
 import { ReactiveSignal } from '../internals/reactive.js';
 import { snapshot } from '../internals/utils/snapshot.js';
 import { useScope } from './context.js';
-import { useSignalsSuspended } from './suspend-signals-context.js';
+import { usePauseSignalsManager } from './pause-signals-context.js';
 import { getGlobalScope } from '../internals/contexts.js';
 
-const useReactiveFnSignal = <R, Args extends unknown[]>(signal: ReactiveSignal<R, Args>): ReactiveValue<R> => {
-  const suspended = useSignalsSuspended();
+function useSignalWithSuspension(signal: ReactiveSignal<any, any>) {
+  const manager = usePauseSignalsManager();
+  const watch = !manager?.paused;
 
-  signal.setSuspended(suspended);
+  manager?.register(signal);
+
+  useEffect(() => {
+    return () => manager?.unregister(signal);
+  }, [manager, signal]);
 
   return useSyncExternalStore(
-    signal.addListenerLazy(),
+    signal.addListenerLazy(watch),
     () => signal.value,
     () => signal.value,
   );
-};
+}
 
 /**
  * Subscribe to a reactive thunk without structural cloning. The thunk's
@@ -48,7 +53,7 @@ export function useReactiveShallow<R>(fn: () => R): ReactiveValue<R> {
   const scope = useScope() ?? getGlobalScope();
   const signal = scope.get(def, [] as []);
 
-  return useReactiveFnSignal(signal) as ReactiveValue<R>;
+  return useSignalWithSuspension(signal) as ReactiveValue<R>;
 }
 
 /**
@@ -70,7 +75,8 @@ export function useReactive<R>(fn: () => R): ReactiveValue<R> {
     );
   }
 
-  const suspended = useSignalsSuspended();
+  const manager = usePauseSignalsManager();
+  const watch = !manager?.paused;
 
   const scope = useScope() ?? getGlobalScope();
   const innerSignalRef = useRef<ReactiveSignal<R, []> | undefined>(undefined);
@@ -94,10 +100,14 @@ export function useReactive<R>(fn: () => R): ReactiveValue<R> {
 
   const cloneSignal = cloneSignalRef.current!;
 
-  cloneSignal.setSuspended(suspended);
+  manager?.register(cloneSignal);
+
+  useEffect(() => {
+    return () => manager?.unregister(cloneSignal);
+  }, [manager, cloneSignal]);
 
   return useSyncExternalStore(
-    cloneSignal.addListenerLazy(),
+    cloneSignal.addListenerLazy(watch),
     () => cloneSignal.value as ReactiveValue<R>,
     () => cloneSignal.value as ReactiveValue<R>,
   );

--- a/packages/signalium/src/types.ts
+++ b/packages/signalium/src/types.ts
@@ -12,7 +12,6 @@ export type ReactiveFn<T, Args extends unknown[]> = (...args: Args) => ReactiveV
 export interface Watcher<T> {
   readonly value: ReactiveValue<T>;
   addListener(listener: () => void, opts?: { skipInitial?: boolean }): () => void;
-  setSuspended(suspended: boolean): void;
 }
 
 export interface Notifier {

--- a/packages/signalium/src/utils.ts
+++ b/packages/signalium/src/utils.ts
@@ -37,22 +37,22 @@ export function watchOnce<T>(fn: () => T): T {
 
   try {
     // Watch the signal to activate any relays
-    watchSignal(signal, false);
+    watchSignal(signal);
 
     // Get the value, which runs the function
     let result = getSignal(signal);
 
     if (isReactivePromise(result as object) || isPromise(result as object)) {
       result = (result as Promise<T>).finally(() => {
-        unwatchSignal(signal, false);
+        unwatchSignal(signal);
       }) as ReactiveValue<T>;
     } else {
-      unwatchSignal(signal, false);
+      unwatchSignal(signal);
     }
 
     return result as T;
   } catch (error) {
-    unwatchSignal(signal, false);
+    unwatchSignal(signal);
     throw error;
   }
 }


### PR DESCRIPTION
Replace the manual GC sweep system with native WeakRef in SignalScope's signal cache. Remove all suspension concepts (suspendCount, setSuspended, isSuspendedListener, suspended watch/unwatch variants) from the core signal graph entirely.

Introduce PauseSignalsProvider (replacing SuspendSignalsProvider) which uses a stable context reference and manages signal watch/unwatch directly via the manager — no React re-render storm on toggle, no suspension state on the signal itself. Signals mounted inside an already-paused provider skip activation entirely.

BREAKING CHANGE: SuspendSignalsProvider renamed to PauseSignalsProvider, useSignalsSuspended and setSuspended removed, native WeakRef required.