### PR TITLE
test(signalium): fix PR 231 checks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,14 +106,14 @@ When a signal has external listeners (React components, watchers):
 
 ### React integration (`src/react/`)
 
-| File                         | Purpose                                                             |
-| ---------------------------- | ------------------------------------------------------------------- |
-| `use-reactive.ts`            | `useReactive()` — main hook bridging signals to React               |
-| `component.tsx`              | `component()` — wraps a function component in a lazy ReactiveSignal |
-| `context.ts`                 | `ScopeContext`, `useScope()`, `useContext()`                        |
-| `provider.tsx`               | `ContextProvider` component                                         |
-| `use-signal.ts`              | `useSignal()` — creates a StateSignal scoped to a component         |
-| `pause-signals-context.ts`   | `PauseSignalsProvider` for pausing signal subscriptions             |
+| File                       | Purpose                                                             |
+| -------------------------- | ------------------------------------------------------------------- |
+| `use-reactive.ts`          | `useReactive()` — main hook bridging signals to React               |
+| `component.tsx`            | `component()` — wraps a function component in a lazy ReactiveSignal |
+| `context.ts`               | `ScopeContext`, `useScope()`, `useContext()`                        |
+| `provider.tsx`             | `ContextProvider` component                                         |
+| `use-signal.ts`            | `useSignal()` — creates a StateSignal scoped to a component         |
+| `pause-signals-context.ts` | `PauseSignalsProvider` for pausing signal subscriptions             |
 
 `useReactive` has three code paths (function, StateSignal, direct ReactivePromise), each calling the same hook pattern: one `useSyncExternalStore` for primary subscription + one for deep dependency tracking via `CONSUME_DEEP`.
 

--- a/docs/src/app/api/signalium/react/page.md
+++ b/docs/src/app/api/signalium/react/page.md
@@ -389,7 +389,7 @@ const TabScreen = component(() => {
 - For permanent cleanup, unmount the component normally — pausing is for temporary resource savings
 - Works with both `useReactive` and `component()` which are the primary signal entry points in React
 
-| Prop     | Type              | Description                       |
-| -------- | ----------------- | --------------------------------- |
-| value    | `boolean`         | Whether to pause (true) or not    |
-| children | `React.ReactNode` | Children to pause/resume          |
+| Prop     | Type              | Description                    |
+| -------- | ----------------- | ------------------------------ |
+| value    | `boolean`         | Whether to pause (true) or not |
+| children | `React.ReactNode` | Children to pause/resume       |

--- a/packages/signalium/src/__tests__/rsc-server-setup.test.ts
+++ b/packages/signalium/src/__tests__/rsc-server-setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, afterEach } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { reactive, setRequestScopeGetter } from 'signalium';
 import { setupRscRequestScope } from '../react/server.js';
 

--- a/packages/signalium/src/internals/reactive.ts
+++ b/packages/signalium/src/internals/reactive.ts
@@ -254,7 +254,6 @@ export class ReactiveSignal<T, Args extends unknown[]> {
 
     return this.listeners.cachedBoundAdd;
   }
-
 }
 
 export const runListeners = (signal: ReactiveSignal<any, any>) => {

--- a/packages/signalium/src/react/pause-signals-context.ts
+++ b/packages/signalium/src/react/pause-signals-context.ts
@@ -39,14 +39,8 @@ class PauseSignalsManager {
 
 const PauseSignalsManagerContext = createContext<PauseSignalsManager | null>(null);
 
-export function PauseSignalsProvider({
-  value,
-  children,
-}: {
-  value: boolean;
-  children: React.ReactNode;
-}) {
-  const managerRef = useRef<PauseSignalsManager>(null);
+export function PauseSignalsProvider({ value, children }: { value: boolean; children: React.ReactNode }) {
+  const managerRef = useRef<PauseSignalsManager | null>(null);
   if (managerRef.current === null) {
     managerRef.current = new PauseSignalsManager(value);
   }


### PR DESCRIPTION
## Summary
- fix PauseSignalsProvider ref typing
- apply Prettier formatting to the files lint flagged

## Verification
- npm ci
- npx -p node@25 -c 'node -v && npm run test:unit --workspace signalium' (v25.9.0)
- npx -p node@25 -c 'node -v && npm run check-types --workspace signalium' (v25.9.0)
- npm run lint
- git diff --check

Note: the ReactivePromise test intentionally keeps native Promise.withResolvers; CI already runs on Node 25.x via .github/workflows/ci.yml. The RSC smoke test uses the real React.cache from the package-local React 19 dependency after npm ci.