### PR TITLE
fix(signalium): remove implicit unhandled-async-error log

### DIFF
--- a/.changeset/remove-unhandled-async-error-log.md
+++ b/.changeset/remove-unhandled-async-error-log.md
@@ -1,0 +1,35 @@
+---
+'signalium': minor
+---
+
+Remove the implicit `console.error('[signalium] Unhandled async error...')`
+that fired whenever a `ReactivePromise` (including `relay()` and `task()`)
+transitioned to a rejected state.
+
+The log was misleading in practice: it ran synchronously inside `_setError`,
+before any reactive consumer or async `component()` had a chance to react. So
+it printed "Unhandled" for rejections that were in fact handled — declaratively
+via `isRejected` / `error` reads, by `await` in an async `component()` (which
+re-throws into a React error boundary), or by an explicit `.catch()` on the
+`ReactivePromise` surface. There's no general definition of "handled" in a
+reactive graph, so any single heuristic was going to mislabel some path.
+
+Rejected `ReactivePromise`s are now silent at the library layer. Existing
+ways to observe a rejection are unchanged:
+
+- Read `isRejected` / `error` on the `ReactivePromise` (or its
+  `useReactive` snapshot) and branch in your reactive code.
+- `await` / `yield` the `ReactivePromise` from an async `component()`; the
+  replay driver throws `error` into the nearest React error boundary on
+  rejection (and throws a thenable for `<Suspense>` while pending).
+- `.catch()` / `.then(null, fn)` on the `ReactivePromise` — it still
+  implements the `Promise` surface.
+
+A first-class global hook for unhandled reactive rejections is intentionally
+deferred: defining "handled" in a way that doesn't mislabel the cases above
+needs more design and isn't required for v3.
+
+If you were relying on the log for debugging, attach your own logging in a
+declarative branch (e.g. inside a `reactive()` that reads `isRejected` /
+`error`) or rethrow from an async `component()` so the error reaches a React
+error boundary.

--- a/packages/signalium/src/__tests__/reactive-promise-methods.test.ts
+++ b/packages/signalium/src/__tests__/reactive-promise-methods.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { signal, ReactivePromise, Signal } from 'signalium';
 import { reactive } from './utils/instrumented-hooks.js';
 import { nextTick, sleep } from './utils/async.js';
@@ -73,20 +73,6 @@ describe('Promise', () => {
       expect(rp.isRejected).toBe(true);
       expect(rp.error).toBe(err);
       await expect(Promise.resolve(rp)).rejects.toBe(err);
-    });
-
-    test('reject handles AbortError when DOMException is unavailable', async () => {
-      const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-      const abortError = new Error('aborted');
-      abortError.name = 'AbortError';
-
-      delete (globalThis as typeof globalThis & { DOMException?: typeof DOMException }).DOMException;
-
-      const rp = ReactivePromise.reject(abortError) as unknown as ReactivePromise<never>;
-      expect(rp.isRejected).toBe(true);
-      expect(rp.error).toBe(abortError);
-      await expect(Promise.resolve(rp)).rejects.toBe(abortError);
-      expect(consoleError).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/signalium/src/internals/async.ts
+++ b/packages/signalium/src/internals/async.ts
@@ -19,14 +19,6 @@ import { getCurrentConsumer } from './consumer.js';
 import { createCallback } from './callback.js';
 import { getTracerProxy, TracerEventType } from './trace.js';
 
-function isAbortError(error: unknown): boolean {
-  if (typeof DOMException !== 'undefined' && error instanceof DOMException) {
-    return error.name === 'AbortError';
-  }
-
-  return error instanceof Error && error.name === 'AbortError';
-}
-
 const enum AsyncFlags {
   // ======= Notifiers ========
 
@@ -492,11 +484,6 @@ export class ReactivePromiseImpl<T> implements IReactivePromise<T> {
   }
 
   private _setError(nextError: unknown, awaitSubs = this._awaitSubs) {
-    if (nextError !== this._error && !isAbortError(nextError)) {
-      const desc = this._signal?.desc ?? (IS_DEV ? this._signal?.tracerMeta?.desc : undefined);
-      console.error(`[signalium] Unhandled async error${desc ? ` in "${desc}"` : ''}:`, nextError);
-    }
-
     let error = this._error;
 
     let notifyFlags = 0;


### PR DESCRIPTION
`_setError` no longer eagerly emits `console.error('[signalium] Unhandled async error...')` when a `ReactivePromise` (including `relay()` / `task()`) rejects. The log fired before any consumer or async `component()` could observe the rejection, so it labeled handled paths as unhandled and the absence/presence of the log didn't reliably correspond to whether the error was actually surfaced.

Rejected `ReactivePromise`s are now silent at the library layer. Existing observation paths are unchanged: declarative reads of `isRejected` / `error`, `await`/`yield` in an async `component()` (which re-throws into the nearest React error boundary), and `.catch()` on the `ReactivePromise` surface.

A first-class hook for unhandled reactive rejections is intentionally deferred until "handled" can be defined without mislabeling these paths.

Also drops the now-unused `isAbortError` helper and the test that asserted on AbortError suppression in the deleted log path.