### PR TITLE
fix(snapshot): apply custom snapshot handlers to subclasses

### DIFF
--- a/.changeset/snapshot-subclass-inheritance.md
+++ b/.changeset/snapshot-subclass-inheritance.md
@@ -1,0 +1,5 @@
+---
+'signalium': patch
+---
+
+Fix `registerCustomSnapshot` to apply to subclasses of the registered class. Previously, a handler registered on a base class was only invoked for direct instances of that class — subclass instances bypassed it because the resolver did an exact-prototype lookup. Custom snapshot registrations now use a non-enumerable symbol on the class prototype, so JS prototype lookup naturally walks the chain and subclasses inherit their ancestor's handler. Subclasses can still override by registering their own handler. The public API is unchanged.

--- a/packages/signalium/src/__tests__/snapshot.test.ts
+++ b/packages/signalium/src/__tests__/snapshot.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from 'vitest';
+import { snapshot, registerCustomSnapshot } from 'signalium/utils';
+
+describe('snapshot', () => {
+  describe('primitives and pass-through', () => {
+    test('returns primitives unchanged', () => {
+      expect(snapshot(undefined, undefined)).toBe(undefined);
+      expect(snapshot(null, null)).toBe(null);
+      expect(snapshot(42, 0)).toBe(42);
+      expect(snapshot('hi', 'hi')).toBe('hi');
+      expect(snapshot(true, false)).toBe(true);
+    });
+
+    test('plain objects are deep-cloned with structural sharing', () => {
+      const prev = { a: 1, nested: { b: 2 } };
+      const current = { a: 1, nested: prev.nested };
+      const result = snapshot(current, prev) as typeof prev;
+
+      expect(result).toEqual({ a: 1, nested: { b: 2 } });
+      expect(result.nested).toBe(prev.nested);
+    });
+
+    test('unregistered class instances are returned as-is', () => {
+      class Plain {
+        constructor(public x: number) {}
+      }
+      const value = new Plain(1);
+      expect(snapshot(value, undefined)).toBe(value);
+    });
+  });
+
+  describe('registerCustomSnapshot — direct match', () => {
+    test('handler is called for instances of the registered class', () => {
+      class Counter {
+        constructor(public count: number) {}
+      }
+      registerCustomSnapshot(Counter, current => ({ count: current.count }) as any);
+
+      const result = snapshot(new Counter(7), undefined) as { count: number };
+      expect(result).toEqual({ count: 7 });
+      expect(result).not.toBeInstanceOf(Counter);
+    });
+
+    test('handler returning prev preserves reference stability', () => {
+      class Box {
+        constructor(public value: number) {}
+      }
+      registerCustomSnapshot(Box, (current, prev) => {
+        if (prev && current.value === (prev as any).value) return prev;
+        return { value: current.value } as any;
+      });
+
+      const prev = { value: 5 };
+      const result = snapshot(new Box(5), prev);
+      expect(result).toBe(prev);
+    });
+  });
+
+  describe('registerCustomSnapshot — prototype-chain walk for subclasses', () => {
+    test('subclass inherits the parent class handler', () => {
+      class Base {
+        constructor(public name: string) {}
+      }
+      registerCustomSnapshot(Base, current => ({ name: (current as Base).name, kind: 'snapshot' }) as any);
+
+      class Child extends Base {
+        constructor(
+          name: string,
+          public extra: number,
+        ) {
+          super(name);
+        }
+      }
+
+      const child = new Child('alice', 99);
+      const result = snapshot(child, undefined) as { name: string; kind: string };
+      expect(result).toEqual({ name: 'alice', kind: 'snapshot' });
+      expect(result).not.toBe(child);
+    });
+
+    test('grandchild inherits handler through multiple levels', () => {
+      class A {
+        constructor(public n: number) {}
+      }
+      registerCustomSnapshot(A, current => ({ from: 'A', n: (current as A).n }) as any);
+
+      class B extends A {}
+      class C extends B {}
+
+      const result = snapshot(new C(3), undefined) as { from: string; n: number };
+      expect(result).toEqual({ from: 'A', n: 3 });
+    });
+
+    test('subclass-registered handler overrides parent handler', () => {
+      class Animal {
+        constructor(public name: string) {}
+      }
+      registerCustomSnapshot(Animal, current => ({ tag: 'animal', name: (current as Animal).name }) as any);
+
+      class Dog extends Animal {
+        constructor(
+          name: string,
+          public breed: string,
+        ) {
+          super(name);
+        }
+      }
+      registerCustomSnapshot(
+        Dog,
+        current => ({ tag: 'dog', name: (current as Dog).name, breed: (current as Dog).breed }) as any,
+      );
+
+      const dog = snapshot(new Dog('rex', 'pug'), undefined) as { tag: string; name: string; breed: string };
+      expect(dog).toEqual({ tag: 'dog', name: 'rex', breed: 'pug' });
+
+      // The base class still uses its own handler.
+      const animal = snapshot(new Animal('whiskers'), undefined) as { tag: string; name: string };
+      expect(animal).toEqual({ tag: 'animal', name: 'whiskers' });
+    });
+
+    test('parent handler can recurse into the actual instance via the snap fn', () => {
+      class Container {
+        constructor(public items: Array<{ id: number; label: string }>) {}
+      }
+      registerCustomSnapshot(Container, (current, prev, snap) => {
+        const items = snap((current as Container).items, (prev as any)?.items) as Array<{
+          id: number;
+          label: string;
+        }>;
+        if (prev && items === (prev as any).items) return prev;
+        return { items } as any;
+      });
+
+      class TaggedContainer extends Container {}
+
+      const prev = snapshot(
+        new TaggedContainer([
+          { id: 1, label: 'a' },
+          { id: 2, label: 'b' },
+        ]),
+        undefined,
+      ) as { items: Array<{ id: number; label: string }> };
+
+      const next = snapshot(
+        new TaggedContainer([
+          { id: 1, label: 'a' },
+          { id: 2, label: 'B' },
+        ]),
+        prev,
+      ) as { items: Array<{ id: number; label: string }> };
+
+      // Item 0 is unchanged → reference shared.
+      expect(next.items[0]).toBe(prev.items[0]);
+      // Item 1 changed → new reference.
+      expect(next.items[1]).not.toBe(prev.items[1]);
+      expect(next.items[1]).toEqual({ id: 2, label: 'B' });
+    });
+
+    test('ancestor registered after the subclass is defined still applies to subclass instances', () => {
+      // Subclass has been snapshotted (and returned as-is) before any
+      // registration exists anywhere in the chain. Once we register on the
+      // ancestor, the next snapshot must pick up the new handler.
+      class LateBase {
+        constructor(public v: number) {}
+      }
+      class LateChild extends LateBase {}
+
+      const beforeRegister = snapshot(new LateChild(1), undefined);
+      expect(beforeRegister).toBeInstanceOf(LateChild);
+
+      registerCustomSnapshot(LateBase, current => ({ v: (current as LateBase).v }) as any);
+
+      const afterRegister = snapshot(new LateChild(2), undefined);
+      expect(afterRegister).toEqual({ v: 2 });
+      expect(afterRegister).not.toBeInstanceOf(LateChild);
+    });
+  });
+
+  describe('built-in handlers are not inherited by subclasses', () => {
+    // The plain-object / Array / Map / Set handlers are intentionally matched
+    // by exact prototype only. This preserves the historical behavior where
+    // a class instance with no custom registration is returned as-is, even
+    // when its base is a built-in container type.
+
+    test('subclass of Array without a custom registration is returned as-is', () => {
+      class MyArray extends Array<number> {}
+      const arr = new MyArray();
+      arr.push(1, 2, 3);
+      expect(snapshot(arr, undefined)).toBe(arr);
+    });
+
+    test('subclass of Map without a custom registration is returned as-is', () => {
+      class MyMap extends Map<string, number> {}
+      const m = new MyMap();
+      m.set('a', 1);
+      expect(snapshot(m, undefined)).toBe(m);
+    });
+
+    test('plain objects still use the built-in handler', () => {
+      const obj = { a: 1, b: 2 };
+      const result = snapshot(obj, undefined) as typeof obj;
+      expect(result).toEqual(obj);
+      expect(result).not.toBe(obj);
+    });
+  });
+});

--- a/packages/signalium/src/internals/utils/snapshot.ts
+++ b/packages/signalium/src/internals/utils/snapshot.ts
@@ -105,8 +105,17 @@ function snapshotSet(current: Set<unknown>, prev: unknown, _snap: SnapshotFn): S
 
   return changed ? result : prevSet!;
 }
-
-const PROTO_TO_SNAPSHOT = new Map<object | null, SnapshotHandler>([
+/**
+ * Built-in handlers for plain structural types. Matched by exact prototype
+ * only — subclasses of `Object` / `Array` / `Map` / `Set` are NOT routed
+ * through these handlers (they fall through and, if no custom ancestor is
+ * registered, are returned as-is). We use a Map here rather than installing
+ * a symbol property on the built-in prototypes, because mutating built-in
+ * prototypes (even with a symbol key) changes their hidden class and
+ * invalidates V8's fast-path inline caches for every plain object / array
+ * in the program.
+ */
+const BUILTIN_PROTO_TO_SNAPSHOT = new Map<object | null, SnapshotHandler>([
   [Object.prototype, snapshotPlainObject],
   [Array.prototype, snapshotArray],
   [Map.prototype, snapshotMap],
@@ -115,9 +124,27 @@ const PROTO_TO_SNAPSHOT = new Map<object | null, SnapshotHandler>([
 ]);
 
 /**
+ * Custom registrations are stored as a non-enumerable symbol property on the
+ * class prototype. JS prototype lookup walks the chain natively, so subclass
+ * inheritance and override-by-redefinition are free — no resolver, no cache,
+ * no invalidation. The symbol is module-private (created with `Symbol()`,
+ * not `Symbol.for()`), so it cannot collide with anything else and cannot
+ * be addressed by user code.
+ */
+const SNAPSHOT_HANDLER = Symbol('signalium.snapshot.handler');
+
+interface MaybeSnapshottable {
+  [SNAPSHOT_HANDLER]?: SnapshotHandler;
+}
+
+/**
  * Register a custom snapshot function for instances of a class.
  * The function receives the current value, the previous snapshot (or undefined),
  * and the recursive `snapshot` function for snapshotting nested values.
+ *
+ * Subclasses inherit the handler automatically via prototype lookup, so
+ * registering once on a base class applies to all descendants. A descendant
+ * can override by registering its own handler.
  *
  * Return `prev` when nothing has changed to preserve reference stability.
  *
@@ -135,7 +162,15 @@ export const registerCustomSnapshot = <T extends object>(
   ctor: new (...args: any[]) => T,
   snapshotFn: (current: T, prev: T | undefined, snapshot: SnapshotFn) => T,
 ): void => {
-  PROTO_TO_SNAPSHOT.set(ctor.prototype, snapshotFn);
+  // Use defineProperty so the handler is non-enumerable (it shouldn't show up
+  // in `Reflect.ownKeys` walks any more than necessary) and so re-registration
+  // overwrites cleanly even if a subclass has shadowed it.
+  Object.defineProperty(ctor.prototype, SNAPSHOT_HANDLER, {
+    value: snapshotFn as SnapshotHandler,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
 };
 
 /**
@@ -143,7 +178,8 @@ export const registerCustomSnapshot = <T extends object>(
  *
  * - Plain objects and arrays are deep-cloned; unchanged subtrees keep the same reference.
  * - ReactivePromise instances are read (establishing deps) and flattened to a plain object.
- * - Class instances (non-plain prototypes) are returned as-is unless a custom handler is registered.
+ * - Class instances are returned as-is unless a custom handler is registered
+ *   for the class or any of its ancestors via `registerCustomSnapshot`.
  * - Primitives are returned directly.
  */
 export function snapshot(currentValue: unknown, prevValue: unknown): unknown {
@@ -155,10 +191,17 @@ export function snapshot(currentValue: unknown, prevValue: unknown): unknown {
     return snapshotReactivePromise(currentValue as ReactivePromiseImpl<unknown>, prevValue, snapshot);
   }
 
-  const handler = PROTO_TO_SNAPSHOT.get(getProto(currentValue));
+  // Custom registrations check first: native prototype lookup walks the chain
+  // for us, so subclasses inherit their ancestor's handler with no extra work.
+  const customHandler = (currentValue as MaybeSnapshottable)[SNAPSHOT_HANDLER];
+  if (customHandler !== undefined) {
+    return customHandler(currentValue, prevValue, snapshot);
+  }
 
-  if (handler !== undefined) {
-    return handler(currentValue, prevValue, snapshot);
+  // Built-in handlers are looked up by exact prototype only.
+  const builtIn = BUILTIN_PROTO_TO_SNAPSHOT.get(getProto(currentValue));
+  if (builtIn !== undefined) {
+    return builtIn(currentValue, prevValue, snapshot);
   }
 
   return currentValue;

--- a/packages/signalium/src/react/__tests__/use-reactive-deep.test.tsx
+++ b/packages/signalium/src/react/__tests__/use-reactive-deep.test.tsx
@@ -835,6 +835,53 @@ describe('React > useReactive (deep, default)', () => {
       expect(second.items[1]).toBe(first.items[1]);
       expect(second.items[0]).not.toBe(first.items[0]);
     });
+
+    test('custom snapshot registered on a base class applies to subclasses', async () => {
+      class Entity {
+        constructor(
+          public id: number,
+          public name: string,
+        ) {}
+      }
+
+      registerCustomSnapshot(Entity, (current, prev, snap) => {
+        const name = snap((current as Entity).name, (prev as any)?.name) as string;
+        const id = (current as Entity).id;
+        if (prev && id === (prev as any).id && name === (prev as any).name) return prev;
+        return { id, name } as any;
+      });
+
+      // Subclass with no separate registration — should still flow through the
+      // base-class handler via the prototype chain.
+      class User extends Entity {}
+
+      const name = signal('Alice');
+      const derived = reactive(() => new User(1, name.value));
+
+      const snapshots: any[] = [];
+
+      function Component(): React.ReactNode {
+        const result = useReactive(() => derived()) as any;
+        snapshots.push(result);
+        return <div data-testid="out">{result.name}</div>;
+      }
+
+      const { getByTestId } = render(<Component />);
+
+      await expect.element(getByTestId('out')).toHaveTextContent('Alice');
+
+      const first = snapshots[snapshots.length - 1];
+      expect(first).toEqual({ id: 1, name: 'Alice' });
+      expect(first).not.toBeInstanceOf(User);
+
+      name.value = 'Bob';
+
+      await expect.element(getByTestId('out')).toHaveTextContent('Bob');
+
+      const second = snapshots[snapshots.length - 1];
+      expect(second).toEqual({ id: 1, name: 'Bob' });
+      expect(second).not.toBe(first);
+    });
   });
 
   describe('null-prototype objects', () => {


### PR DESCRIPTION
Fix `registerCustomSnapshot` to apply to subclasses of the registered class. Previously, a handler registered on a base class was only invoked for direct instances of that class — subclass instances bypassed it because the resolver did an exact-prototype lookup. Custom snapshot registrations now use a non-enumerable symbol on the class prototype, so JS prototype lookup naturally walks the chain and subclasses inherit their ancestor's handler. Subclasses can still override by registering their own handler. The public API is unchanged.