### PR TITLE
fix: add run to reactive promise snapshots

### DIFF
--- a/packages/signalium/src/internals/utils/snapshot.ts
+++ b/packages/signalium/src/internals/utils/snapshot.ts
@@ -58,6 +58,14 @@ function snapshotReactivePromise(current: ReactivePromiseImpl<unknown>, prev: un
   const isReady = current.isReady;
   const isSettled = current.isSettled;
 
+  // `run` is set once in the task constructor and never mutated, so its identity
+  // is stable for the lifetime of the underlying ReactivePromiseImpl. Carrying
+  // it on the snapshot lets consumers (e.g. React components reading a task via
+  // `useReactive`) invoke `result.run(...)` against the live task. For non-task
+  // promises this is `undefined`; we still assign the slot so the resulting
+  // object's hidden class is stable across task and non-task snapshots.
+  const run = (current as unknown as { run: ((...args: unknown[]) => unknown) | undefined }).run;
+
   if (
     prevObj &&
     value === prevObj.value &&
@@ -66,12 +74,13 @@ function snapshotReactivePromise(current: ReactivePromiseImpl<unknown>, prev: un
     isRejected === prevObj.isRejected &&
     isResolved === prevObj.isResolved &&
     isReady === prevObj.isReady &&
-    isSettled === prevObj.isSettled
+    isSettled === prevObj.isSettled &&
+    run === prevObj.run
   ) {
     return prevObj;
   }
 
-  return { value, error, isPending, isRejected, isResolved, isReady, isSettled };
+  return { value, error, isPending, isRejected, isResolved, isReady, isSettled, run };
 }
 
 function snapshotMap(current: Map<unknown, unknown>, prev: unknown, snap: SnapshotFn): Map<unknown, unknown> {

--- a/packages/signalium/src/react/__tests__/use-reactive-deep.test.tsx
+++ b/packages/signalium/src/react/__tests__/use-reactive-deep.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { render } from 'vitest-browser-react';
-import { signal, reactive } from 'signalium';
+import { signal, reactive, task } from 'signalium';
 import { registerCustomSnapshot, snapshot } from 'signalium/utils';
 import { useReactive } from 'signalium/react';
 import React, { memo, useState } from 'react';
@@ -474,6 +474,44 @@ describe('React > useReactive (deep, default)', () => {
       const secondResolved = snapshots[snapshots.length - 1];
       expect(secondResolved.value).toEqual({ user: { name: 'Bob' } });
       expect(secondResolved.value).not.toBe(firstResolved.value);
+    });
+
+    test('snapshot of a ReactiveTask exposes a callable `run`', async () => {
+      const greetTask = reactive(() =>
+        task(async (name: string) => {
+          await sleep(50);
+          return `Hello, ${name}`;
+        }),
+      );
+
+      const snapshots: any[] = [];
+
+      function Component(): React.ReactNode {
+        const result = useReactive(() => greetTask()) as any;
+        snapshots.push(result);
+        return (
+          <div>
+            <div data-testid="value">{result.value ?? 'idle'}</div>
+            <button onClick={() => result.run('World')}>run</button>
+          </div>
+        );
+      }
+
+      const { getByTestId, getByText } = render(<Component />);
+
+      await expect.element(getByTestId('value')).toHaveTextContent('idle');
+
+      const initial = snapshots[snapshots.length - 1];
+      expect(typeof initial.run).toBe('function');
+
+      await userEvent.click(getByText('run'));
+
+      await expect.element(getByTestId('value')).toHaveTextContent('Hello, World');
+
+      const settled = snapshots[snapshots.length - 1];
+      // `run` identity is stable across the lifetime of the underlying task,
+      // so the snapshot's `run` reference shouldn't change between transitions.
+      expect(settled.run).toBe(initial.run);
     });
   });
 


### PR DESCRIPTION
Fix `useReactive` snapshots of `ReactiveTask` to carry over the `run` method. Previously, when a task was read through `useReactive`, the deep-snapshot returned a plain object with `value`/`error`/`isPending`/etc. but no `run`, so consumers couldn't invoke `result.run(...)` against the underlying task. The snapshot now includes `run`, and its identity is included in the structural-equality short-circuit so reference stability across pending → resolved transitions is preserved.