### PR TITLE
Distinguish pause from cleanup in relay deactivation

### DIFF
--- a/.changeset/relay-pause-deactivate.md
+++ b/.changeset/relay-pause-deactivate.md
@@ -1,0 +1,5 @@
+---
+"signalium": patch
+---
+
+`RelayHooks.deactivate` now receives a `DeactivateOptions` object with an `isPausing` flag, distinguishing a temporary pause (e.g. `PauseSignalsProvider`) from a genuine cleanup. Relays can use it to skip destructive work like garbage collection while pausing. `DeactivateOptions` is exported.

--- a/packages/signalium/src/__tests__/relay-pause-deactivate.test.ts
+++ b/packages/signalium/src/__tests__/relay-pause-deactivate.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from 'vitest';
+import { reactive, relay, watcher } from '../index.js';
+import { watchSignal, unwatchSignal } from '../internals/watch.js';
+import { ReactiveSignal } from '../internals/reactive.js';
+import { nextTick } from './utils/async.js';
+
+describe('relay deactivate distinguishes pause from cleanup', () => {
+  /**
+   * A relay torn down because its watchers were temporarily paused (e.g.
+   * PauseSignalsProvider toggling to `true`) must report `isPausing === true`
+   * so consumers like fetchium can skip destructive work such as scheduling
+   * garbage collection. A genuine cleanup reports `isPausing === false`.
+   */
+  test('pause passes isPausing=true; cleanup passes isPausing=false', async () => {
+    const deactivations: boolean[] = [];
+
+    const sub = relay<number>(state => {
+      state.value = 1;
+      return {
+        deactivate: ({ isPausing = false } = {}) => {
+          deactivations.push(isPausing);
+        },
+      };
+    });
+
+    const computed = reactive(() => sub.value);
+    const w = watcher(() => computed());
+    const sig = w as unknown as ReactiveSignal<any, any>;
+
+    const unsub = w.addListener(() => {});
+    await nextTick();
+    expect(w.value).toBe(1);
+
+    // Pause: unwatch with isPausing = true (PauseSignalsManager.setPaused(true)).
+    unwatchSignal(sig, { isPausing: true });
+    await nextTick();
+    expect(deactivations).toEqual([true]);
+
+    // Resume, then a genuine cleanup unwatch.
+    watchSignal(sig);
+    await nextTick();
+    expect(w.value).toBe(1);
+
+    unwatchSignal(sig);
+    await nextTick();
+    expect(deactivations).toEqual([true, false]);
+
+    unsub();
+  });
+});

--- a/packages/signalium/src/index.ts
+++ b/packages/signalium/src/index.ts
@@ -1,5 +1,6 @@
 export {
   type Context,
+  type DeactivateOptions,
   type Equals,
   type Notifier,
   type PendingReactivePromise,

--- a/packages/signalium/src/internals/async.ts
+++ b/packages/signalium/src/internals/async.ts
@@ -7,6 +7,7 @@ import {
   RelayActivate,
   RelayHooks,
   RelayState,
+  type DeactivateOptions,
 } from '../types.js';
 import { createReactiveSignal, ReactiveSignal, ReactiveDefinition, ReactiveFnState } from './reactive.js';
 import { disconnectSignal, getSignal } from './get.js';
@@ -733,11 +734,11 @@ export function createRelay<T>(activate: RelayActivate<T>, scope: SignalScope, o
   let active = false;
   let currentSub: RelayHooks | (() => void) | undefined | void;
 
-  const unsubscribe = () => {
+  const unsubscribe = (options?: DeactivateOptions) => {
     if (typeof currentSub === 'function') {
       currentSub();
     } else if (currentSub !== undefined) {
-      currentSub.deactivate?.();
+      currentSub.deactivate?.(options);
     }
 
     const signal = p['_signal'] as ReactiveSignal<any, any>;
@@ -771,7 +772,7 @@ export function createRelay<T>(activate: RelayActivate<T>, scope: SignalScope, o
     },
   };
 
-  const def: ReactiveDefinition<() => void, unknown[]> = {
+  const def: ReactiveDefinition<(options?: DeactivateOptions) => void, unknown[]> = {
     compute: () => {
       if (active === false) {
         currentSub = activate(state);

--- a/packages/signalium/src/internals/scheduling.ts
+++ b/packages/signalium/src/internals/scheduling.ts
@@ -1,5 +1,6 @@
 import { scheduleFlush as _scheduleFlush, runBatch } from './config.js';
 import { ReactiveSignal } from './reactive.js';
+import type { DeactivateOptions } from '../types.js';
 import { checkAndRunListeners, checkSignal } from './get.js';
 import { runListeners as runDerivedListeners } from './reactive.js';
 import { runListeners as runStateListeners } from './signal.js';
@@ -9,7 +10,9 @@ import { StateSignal } from './signal.js';
 
 let PENDING_PULLS: Set<ReactiveSignal<any, any>> = new Set();
 let PENDING_ASYNC_PULLS: ReactiveSignal<any, any>[] = [];
-let PENDING_DEACTIVE = new Set<ReactiveSignal<any, any>>();
+// Maps each pending signal to its deactivation context (pause vs cleanup).
+// Clean wins on conflict.
+let PENDING_DEACTIVE = new Map<ReactiveSignal<any, any>, DeactivateOptions>();
 let PENDING_LISTENERS: (ReactiveSignal<any, any> | StateSignal<any>)[] = [];
 let PENDING_TRACERS: Tracer[] | undefined = IS_DEV ? [] : undefined;
 
@@ -42,8 +45,14 @@ export const scheduleAsyncPull = (signal: ReactiveSignal<any, any>) => {
   scheduleFlush(flushWatchers);
 };
 
-export const scheduleDeactivate = (signal: ReactiveSignal<any, any>) => {
-  PENDING_DEACTIVE.add(signal);
+export const scheduleDeactivate = (signal: ReactiveSignal<any, any>, options: DeactivateOptions = {}) => {
+  const existing = PENDING_DEACTIVE.get(signal);
+  // A genuine cleanup must never be downgraded to a pause: if this signal was
+  // already scheduled as a clean, keep it a clean.
+  PENDING_DEACTIVE.set(
+    signal,
+    existing === undefined ? options : { isPausing: Boolean(existing.isPausing && options.isPausing) },
+  );
   scheduleFlush(flushWatchers);
 };
 
@@ -99,8 +108,8 @@ const flushWatchers = async () => {
   currentFlush = null;
 
   runBatch(() => {
-    for (const signal of PENDING_DEACTIVE) {
-      deactivateSignal(signal);
+    for (const [signal, options] of PENDING_DEACTIVE) {
+      deactivateSignal(signal, options);
     }
 
     PENDING_DEACTIVE.clear();

--- a/packages/signalium/src/internals/watch.ts
+++ b/packages/signalium/src/internals/watch.ts
@@ -1,4 +1,5 @@
 import { ReactiveSignal, isRelay } from './reactive.js';
+import type { DeactivateOptions } from '../types.js';
 import { checkSignal } from './get.js';
 import { cancelDeactivate, scheduleDeactivate } from './scheduling.js';
 
@@ -19,14 +20,14 @@ export function watchSignal(signal: ReactiveSignal<any, any>): void {
   activateSignal(signal);
 }
 
-export function unwatchSignal(signal: ReactiveSignal<any, any>) {
+export function unwatchSignal(signal: ReactiveSignal<any, any>, options: DeactivateOptions = {}) {
   const { watchCount } = signal;
   const newWatchCount = Math.max(watchCount - 1, 0);
 
   signal.watchCount = newWatchCount;
 
   if (newWatchCount === 0) {
-    scheduleDeactivate(signal);
+    scheduleDeactivate(signal, options);
   }
 }
 
@@ -40,7 +41,7 @@ export function activateSignal(signal: ReactiveSignal<any, any>): void {
   }
 }
 
-export function deactivateSignal(signal: ReactiveSignal<any, any>) {
+export function deactivateSignal(signal: ReactiveSignal<any, any>, options: DeactivateOptions = {}) {
   signal._isActive = false;
 
   for (const dep of signal.deps.keys()) {
@@ -48,11 +49,11 @@ export function deactivateSignal(signal: ReactiveSignal<any, any>) {
     dep.watchCount = newWatchCount;
 
     if (newWatchCount === 0) {
-      deactivateSignal(dep);
+      deactivateSignal(dep, options);
     }
   }
 
   if (isRelay(signal)) {
-    signal._value?.();
+    signal._value?.(options);
   }
 }

--- a/packages/signalium/src/react/pause-signals-context.ts
+++ b/packages/signalium/src/react/pause-signals-context.ts
@@ -28,7 +28,7 @@ class PauseSignalsManager {
     this._paused = value;
     for (const signal of this.signals) {
       if (value) {
-        unwatchSignal(signal);
+        unwatchSignal(signal, { isPausing: true });
       } else {
         watchSignal(signal);
         schedulePull(signal);

--- a/packages/signalium/src/types.ts
+++ b/packages/signalium/src/types.ts
@@ -21,9 +21,29 @@ export interface Notifier {
 
 export type Equals<T> = (prev: T, next: T) => boolean;
 
+/**
+ * Context passed to {@link RelayHooks.deactivate} (and threaded through
+ * signalium's internal deactivation path). An options object rather than a
+ * positional flag so more context can be added without a breaking change.
+ */
+export interface DeactivateOptions {
+  /**
+   * `true` when the relay is being torn down by a temporary pause (e.g. via
+   * `PauseSignalsProvider`) that will likely resume, and `false`/absent for a
+   * genuine cleanup (no remaining watchers). Relays should avoid scheduling
+   * destructive work like garbage collection while pausing, so that resuming
+   * can reuse the existing state.
+   */
+  isPausing?: boolean;
+}
+
 export type RelayHooks = {
   update?(): void;
-  deactivate?(): void;
+  /**
+   * Called when the relay is torn down. See {@link DeactivateOptions.isPausing}
+   * for distinguishing a temporary pause from a genuine cleanup.
+   */
+  deactivate?(options?: DeactivateOptions): void;
 };
 
 export interface RelayState<T> {


### PR DESCRIPTION
## Problem

Relay teardown couldn't distinguish a temporary pause from a genuine cleanup. Both ran the same path, so a consumer that does destructive work on teardown (e.g. scheduling garbage collection) couldn't avoid it when a relay was only being paused and would resume shortly. The relay's cached state would be torn down and recreated on resume.

## Change

Thread an `isPausing` flag through the deactivation path down to the relay hook:

```
PauseSignalsManager.setPaused(true)
  -> unwatchSignal(sig, { isPausing: true })
  -> scheduleDeactivate(sig, options)
  -> deactivateSignal(sig, options)      // cascades to relay deps
  -> relay unsubscribe(options)
  -> RelayHooks.deactivate(options)       // consumer decides what to do
```

`RelayHooks.deactivate` now receives a `DeactivateOptions` object (`{ isPausing }`), exported from the package. `isPausing` is `true` for a pause (e.g. `PauseSignalsProvider`) and `false`/absent for a real cleanup (no remaining watchers). An options object rather than a positional flag so more context can be added later without a breaking change.

`PENDING_DEACTIVE` is keyed by the options so a queued cleanup is never downgraded to a pause.

Patch changeset included.