### PR TITLE
ci(release): sign changesets commits via github-api commit mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,10 @@ permissions:
 
 jobs:
   release:
-    permissions: write-all
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     name: Release
     runs-on: ubuntu-latest
     environment: production
@@ -34,6 +37,8 @@ jobs:
         uses: changesets/action@v1
         with:
           publish: npm run release
+          # `main` requires signed commits; github-api mode signs with GitHub's key
+          commitMode: github-api
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Problem

`main` enforces a required-signatures ruleset, but `changesets/action` defaults to `commitMode: git-cli`, which produces unsigned commits. Every `Version Packages` PR therefore lands unmergeable and has to be re-signed by hand.

## Fix

Set `commitMode: github-api`. Per the action's `action.yml`, that mode routes commits and tags through the GitHub API, where they are "signed using GitHub's GPG key and attributed to the user or app who owns the `GITHUB_TOKEN`" — i.e. `github-actions[bot]`, Verified.

No org-level setup is involved: signing happens server-side with GitHub's key, so the existing repository-scoped `${{ secrets.GITHUB_TOKEN }}` is sufficient and no signing secret or GitHub App install is needed.

Note that `setupGitUser` becomes a no-op under this mode, since commits no longer go through the git CLI.

## Also

Narrows the job's `permissions: write-all` to what it actually uses:

- `contents: write` — release commits, tags, GitHub releases
- `pull-requests: write` — creating and updating the version PR
- `id-token: write` — required by `NPM_CONFIG_PROVENANCE: true`

## Verification

The next `Version Packages` PR is the real test; this cannot be exercised without a release run. Confirmed statically that `commitMode` exists on the pinned `changesets/action@v1` ref and that the edited workflow parses as intended.

Same change as Signalium/fetchium#52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)